### PR TITLE
Fixes and Cleanups for NCI Collection 2 Processing

### DIFF
--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -7,7 +7,7 @@ from airflow.contrib.operators.ssh_operator import SSHOperator
 from datetime import datetime, timedelta
 
 default_args = {
-    'owner': 'dayers',
+    'owner': 'Damien Ayers',
     'start_date': datetime(2020, 3, 12),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),

--- a/dags/nci_build_dea_unstable_module.py
+++ b/dags/nci_build_dea_unstable_module.py
@@ -12,7 +12,7 @@ from airflow.operators.email_operator import EmailOperator
 local_tz = pendulum.timezone("Australia/Canberra")
 
 default_args = {
-    'owner': 'dayers',
+    'owner': 'Damien Ayers',
     'start_date': datetime(2020, 3, 12, tzinfo=local_tz),
     'retries': 1,
     'retry_delay': timedelta(minutes=10),

--- a/dags/nci_build_dea_unstable_module.py
+++ b/dags/nci_build_dea_unstable_module.py
@@ -59,7 +59,7 @@ with dag:
 
     send_email = EmailOperator(
         task_id='send_email',
-        to=['damien@omad.net', 'damien.ayers@ga.gov.au'],
+        to=['damien.ayers@ga.gov.au'],
         subject='New dea/unstable Module',
         html_content='Successfully built new dea/unstable module on the NCI',
         mime_charset='utf-8',

--- a/dags/nci_build_dea_unstable_module.py
+++ b/dags/nci_build_dea_unstable_module.py
@@ -59,7 +59,7 @@ with dag:
 
     send_email = EmailOperator(
         task_id='send_email',
-        to='damien@omad.net',
+        to=['damien@omad.net', 'damien.ayers@ga.gov.au'],
         subject='New dea/unstable Module',
         html_content='Successfully built new dea/unstable module on the NCI',
         mime_charset='utf-8',

--- a/dags/nci_build_env_module.py
+++ b/dags/nci_build_env_module.py
@@ -7,7 +7,7 @@ from airflow.contrib.operators.ssh_operator import SSHOperator
 from datetime import datetime, timedelta
 
 default_args = {
-    'owner': 'dayers',
+    'owner': 'Damien Ayers',
     'start_date': datetime(2020, 3, 12),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),

--- a/dags/nci_dataset_ingest.py
+++ b/dags/nci_dataset_ingest.py
@@ -61,10 +61,9 @@ with ingest_dag:
     """
 
     save_tasks_command = dedent(COMMON + """
-        {% set ingestion_config = '/g/data/v10/public/modules/' + params.module + 
-            '/lib/python3.6/site-packages/digitalearthau/config/ingestion/' + params.ing_product + '.yaml' %}
+        INGESTION_CONFIG=/g/data/v10/public/modules/$(module info-loaded dea)/lib/python3.6/site-packages/digitalearthau/config/ingestion/{{ params.ing_product }}.yaml
             
-        datacube -v ingest --year {{params.year}} --config-file {{ingestion_config}} --save-tasks {{task_file}}
+        datacube -v ingest --year {{params.year}} --config-file ${INGESTION_CONFIG} --save-tasks {{task_file}}
     """)
 
     test_tasks_command = dedent(COMMON + """
@@ -72,8 +71,6 @@ with ingest_dag:
     """)
 
     qsubbed_ingest_command = dedent(COMMON + """
-        {% set distributed_script = '/g/data/v10/public/modules/' + params.module + 
-            '/lib/python3.6/site-packages/digitalearthau/run_distributed.sh' %}
         {% set distributed_script = '/home/547/lpgs/bin/run_distributed.sh' %}
 
         qsub \

--- a/dags/nci_db_backup.py
+++ b/dags/nci_db_backup.py
@@ -40,7 +40,7 @@ with DAG('nci_db_backup',
         # Load dea module to ensure that pg_dump version and the server version
         # matches, when the cronjob is run from an ec2 instance
         module use /g/data/v10/public/modules/modulefiles
-        module load dea/20191127
+        module load dea
 
         cd /g/data/v10/agdc/backup/archive
 

--- a/dags/nci_index_s2ard_simple.py
+++ b/dags/nci_index_s2ard_simple.py
@@ -33,7 +33,7 @@ default_args = {
     'retry_delay': timedelta(minutes=5),
     'params': {
         'project': 'v10',
-        'module': 'dea/unstable',
+        'module': 'dea',
         'queue': 'normal',
     }
 }
@@ -51,7 +51,7 @@ with DAG('nci_index_s2ard_simple',
         ssh_conn_id='lpgs_gadi',
         command=dedent('''
         set -eu
-        module load dea/unstable
+        module load {{ params.module }}
 
         cd /g/data/if87/datacube/002/S2_MSI_ARD/packaged
 

--- a/dags/nci_wofs.py
+++ b/dags/nci_wofs.py
@@ -38,7 +38,7 @@ with dag:
           module load {{ params.module }};
 
           set -eux
-          APP_CONFIG=/g/data/v10/public/modules/{{params.module}}/wofs/config/wofs_albers.yaml
+          APP_CONFIG=/g/data/v10/public/modules/$(module module-info dea)/wofs/config/wofs_albers.yaml
     """
     generate_wofs_tasks = SSHOperator(
         task_id='generate_wofs_tasks',

--- a/dags/testdag.py
+++ b/dags/testdag.py
@@ -17,7 +17,7 @@ default_args = {
 
     'depends_on_past': False,
     'start_date': datetime(2020, 2, 1),
-    'email': ['damien.ayers@ga.gov.au', 'damien@omad.net'],
+    'email': ['damien.ayers@ga.gov.au'],
     'email_on_failure': True,
 }
 
@@ -59,7 +59,7 @@ with dag:
 
     send_email = EmailOperator(
         task_id='send_email',
-        to='damien@omad.net',
+        to='example@example.com',
         subject='New dea/unstable Module',
         html_content='Successfully built new dea/unstable module on the NCI',
         mime_charset='utf-8',
@@ -71,7 +71,7 @@ with dag:
     # )
     upload_template_var = TemplateToSFTPOperator(
         task_id='upload_template_var',
-        ssh_conn_id='omad_localhost',
+        ssh_conn_id='localhost',
         remote_filepath='/home/omad/{{ ds }}test.txt',
         file_contents="testtemplate.jinja2",
         create_intermediate_dirs=False,

--- a/plugins/operators/ssh_operators.py
+++ b/plugins/operators/ssh_operators.py
@@ -16,7 +16,7 @@ from dea_airflow_common.ssh import SSHRunMixin
 
 class ShortCircuitSSHOperator(SSHRunMixin, BaseOperator, SkipMixin):
     """
-    Execute an SSH command and then Optionally Short Circuit
+    Execute an SSH command and then Optionally Short Circuit DAG execution
 
     The condition is determined by the return value of running `command`
     on the provided SSH host..


### PR DESCRIPTION
- Make COG conversion and uploading more robust (may still need more improvements)
- Make owner names consistent
- Switch more DAGs from `dea/unstable` to `dea` module
- Fix mistake when switching away from using the `dea/unstable` module to the stable one.