### PR TITLE
New Docker Compose setup for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,18 @@ accident, but haven't come up with anything yet.
 If you have Docker available, by far the easiest development setup is to use
 Docker Compose.
 
+First, initialise some environment variables:
+
 ``` bash
-python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())' 
-docker-compose up
-
-docker-compose exec webserver /bin/bash
-. /entrypoint.sh
-airflow connections --add --conn_id lpgs_gadi --conn_uri 'ssh://dra547@gadi.nci.org.au'
-
+python -c 'from cryptography.fernet import Fernet; print("FERNET_KEY=" + Fernet.generate_key().decode())' > .env
+echo UID=`id -u` >> .env
+echo GID=`id -g` >> .env
 ```
 
+Then start up `docker-compose`:
+
 ``` bash
 docker-compose up
-docker-compose exec 
-docker-compose run --rm webserver airflow upgradedb
-docker-compose run --rm webserver airflow connections --add --conn_id lpgs_gadi --conn_uri ssh://dra547@gadi.nci.org.au/
-docker-compose exec webserver /entrypoint.sh airflow connections --add --conn_id dea_public_data_upload --conn_uri s3://foo:bar@dea-public-data-dev/
 ```
 
 ## Local Editing of DAG's
@@ -48,7 +44,7 @@ pip install pylint pylint-airflow
 pylint dags plugins
 ```
 
-### Pre-commit setup
+## Pre-commit setup
 
 A [pre-commit](https://pre-commit.com/) config is provided to automatically format
 and check your code changes. This allows you to immediately catch and fix

--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
-# Geoscience Australia DEA Airflow DAG's repository
+# Geoscience Australia DEA Airflow DAGs repository
+
+## Deployment Workflow
+
+This repository contains two branches, `master` and `develop`.
+
+The `master` branch requires Pull Requests and reviews to merge code into, and
+is deployed automatically to the Production (Sandbox) Airflow deployment.
+
+The `develop` branch can be committed to directly, or via Pull Request, and is
+deployed automatically to the Development Airflow deployment.
+
+We're not happy with this strategy, and are looking for an alternative that
+doesn't have us deploying and inadvertently running code in multiple places by
+accident, but haven't come up with anything yet.
 
 ## Development
 
+## Using Docker
+## Development
+
+### Local Editing of DAG's
+If you have Docker available, by far the easiest development setup is to use
+Docker Compose.
+
+``` bash
+python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())' 
+docker-compose up
+
+docker-compose exec webserver /bin/bash
+. /entrypoint.sh
+airflow connections --add --conn_id lpgs_gadi --conn_uri 'ssh://dra547@gadi.nci.org.au'
+
+```
+
+``` bash
+docker-compose up
+docker-compose exec 
+docker-compose run --rm webserver airflow upgradedb
+docker-compose run --rm webserver airflow connections --add --conn_id lpgs_gadi --conn_uri ssh://dra547@gadi.nci.org.au/
+docker-compose exec webserver /entrypoint.sh airflow connections --add --conn_id dea_public_data_upload --conn_uri s3://foo:bar@dea-public-data-dev/
+```
+
 ### Local Editing of DAG's
 
-DAG's can be locally edited and validated. Development can be done in `conda` or `venv` according to developer preference. Grab everything airflow and write DAG's. Use `autopep8` and `pylint` to achieve import validation and consistent formatting as the CI pipeline for this repository matures.
+DAGs can be locally edited and validated. Development can be done in `conda` or `venv` according to developer preference. Grab everything airflow and write DAGs. Use `autopep8` and `pylint` to achieve import validation and consistent formatting as the CI pipeline for this repository matures.
 
 ```bash
 pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]

--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@
 
 This repository contains two branches, `master` and `develop`.
 
-The `master` branch requires Pull Requests and reviews to merge code into, and
-is deployed automatically to the Production (Sandbox) Airflow deployment.
+The `master` branch requires Pull Requests and code reviews to merge code into
+it. It deploys automatically to the [Production (Sandbox) Airflow deployment](https://airflow.sandbox.dea.ga.gov.au/home).
 
-The `develop` branch can be committed to directly, or via Pull Request, and is
-deployed automatically to the Development Airflow deployment.
+The `develop` branch accepts pushes directly, or via Pull Request, and deploys
+automatically to the [Development Airflow](https://airflow.dev.dea.ga.gov.au/home).
 
 We're not happy with this strategy, and are looking for an alternative that
 doesn't have us deploying and inadvertently running code in multiple places by
 accident, but haven't come up with anything yet.
 
-## Development
+## Development Using Docker
 
-## Using Docker
-## Development
-
-### Local Editing of DAG's
 If you have Docker available, by far the easiest development setup is to use
 Docker Compose.
 
@@ -41,7 +37,7 @@ docker-compose run --rm webserver airflow connections --add --conn_id lpgs_gadi 
 docker-compose exec webserver /entrypoint.sh airflow connections --add --conn_id dea_public_data_upload --conn_uri s3://foo:bar@dea-public-data-dev/
 ```
 
-### Local Editing of DAG's
+## Local Editing of DAG's
 
 DAGs can be locally edited and validated. Development can be done in `conda` or `venv` according to developer preference. Grab everything airflow and write DAGs. Use `autopep8` and `pylint` to achieve import validation and consistent formatting as the CI pipeline for this repository matures.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,45 +1,83 @@
 version: '3.7'
 services:
   postgres:
-    image: postgres:9.6
+    image: postgres:12
     environment:
       - POSTGRES_USER=airflow
       - POSTGRES_PASSWORD=airflow
       - POSTGRES_DB=airflow
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
-      - ./pgdata:/var/lib/postgresql/data/pgdata
+      - pgdata:/var/lib/postgresql/data/pgdata
     logging:
       options:
         max-size: 10m
         max-file: "3"
+  setup-airflow:
+    image: apache/airflow:1.10.12
+    depends_on:
+      - postgres
+    environment: &env
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql://airflow:airflow@postgres/airflow
+      # Uncomment and add fernet key to encrypt/decrypt secrets. For details see
+      # https://airflow.readthedocs.io/en/stable/howto/secure-connections.html
+      - AIRFLOW__CORE__FERNET_KEY=${FERNET_KEY}
+      # - EXECUTOR=Local
+      - AIRFLOW__SMTP__SMTP_HOST=maildev
+      - AIRFLOW__CORE__ENABLE_XCOM_PICKLING=False
+      - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+      - HOST_USER_ID=1000
+      - HOST_GROUP_ID=1000
+    command: "bash -c 'airflow upgradedb && airflow connections --add --conn_id lpgs_gadi --conn_uri ssh://dra547@gadi.nci.org.au/ && airflow connections --add --conn_id dea_public_data_upload --conn_uri s3://foo:bar@dea-public-data-dev/ && airflow connections --add --conn_id aws_nci_db_backup --conn_uri s3://foo:bar@dea-db-backups/'"
   webserver:
-    image: geoscienceaustralia/airflow
+    image: apache/airflow:1.10.12
     restart: always
     depends_on:
       - postgres
-    environment:
-      - LOAD_EX=n
-      # Uncomment and add fernet key to encrypt/decrypt secrets. For details see
-      # https://airflow.readthedocs.io/en/stable/howto/secure-connections.html
-      # - FERNET_KEY=<insert-fernet-key-here>
-      - EXECUTOR=Local
-      - AIRFLOW__SMTP__SMTP_HOST=maildev
-      - AIRFLOW__CORE__ENABLE_XCOM_PICKLING=False
+      - setup-airflow
+    environment: *env
     logging:
       options:
         max-size: 10m
         max-file: "3"
     volumes:
-      - ./dags:/usr/local/airflow/dags
-      - ./plugins:/usr/local/airflow/plugins
-      - ./scripts:/usr/local/airflow/scripts
-      - ./requirements.txt:/requirements.txt
+      - ./dags:/opt/airflow/dags
+      - ./plugins:/opt/airflow/plugins
+      - ./scripts:/opt/airflow/scripts
+      - logs/:/opt/airflow/logs
+      - ./requirements.txt:/opt/airflow/requirements.txt
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
     ports:
       - "8080:8080"
     command: webserver
     healthcheck:
-      test: ["CMD-SHELL", "[ -f /usr/local/airflow/airflow-webserver.pid ]"]
+      test: ["CMD-SHELL", "[ -f /opt/airflow/airflow-webserver.pid ]"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+  scheduler:
+    image: apache/airflow:1.10.12
+    restart: always
+    depends_on:
+      - postgres
+      - setup-airflow
+    environment: *env
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - ./dags:/opt/airflow/dags
+      - ./plugins:/opt/airflow/plugins
+      - ./scripts:/opt/airflow/scripts
+      - logs/:/opt/airflow/logs
+      - ./requirements.txt:/opt/airflow/requirements.txt
+      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
+    command: scheduler
+    ports:
+      - "8793:8793"
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /opt/airflow/airflow-scheduler.pid ]"]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -47,3 +85,6 @@ services:
     image: maildev/maildev
     ports:
       - "1080:80"
+volumes:
+  pgdata:
+  logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         max-size: 10m
         max-file: "3"
   setup-airflow:
-    image: apache/airflow:1.10.12
+    image: &image apache/airflow:1.10.11
     depends_on:
       - postgres
     environment: &env
@@ -22,15 +22,18 @@ services:
       # Uncomment and add fernet key to encrypt/decrypt secrets. For details see
       # https://airflow.readthedocs.io/en/stable/howto/secure-connections.html
       - AIRFLOW__CORE__FERNET_KEY=${FERNET_KEY}
-      # - EXECUTOR=Local
       - AIRFLOW__SMTP__SMTP_HOST=maildev
       - AIRFLOW__CORE__ENABLE_XCOM_PICKLING=False
       - AIRFLOW__CORE__EXECUTOR=SequentialExecutor
-      - HOST_USER_ID=1000
-      - HOST_GROUP_ID=1000
-    command: "bash -c 'airflow upgradedb && airflow connections --add --conn_id lpgs_gadi --conn_uri ssh://dra547@gadi.nci.org.au/ && airflow connections --add --conn_id dea_public_data_upload --conn_uri s3://foo:bar@dea-public-data-dev/ && airflow connections --add --conn_id aws_nci_db_backup --conn_uri s3://foo:bar@dea-db-backups/'"
+      # Default Connections Used in the DEA Airflow deployment
+      - AIRFLOW_CONN_LPGS_GADI=ssh://dra547@gadi.nci.org.au/
+      - AIRFLOW_CONN_DEA_PUBLIC_DATA_UPLOAD=s3://foo:bar@dea-public-data-dev/
+      - AIRFLOW_CONN_AWS_NCI_DB_BACKUP=s3://foo:bar@dea-db-backups/
+      - HOST_USER_ID=${UID}
+      - HOST_GROUP_ID=${GID}
+    command: bash -c 'airflow upgradedb'
   webserver:
-    image: apache/airflow:1.10.12
+    image: *image
     restart: always
     depends_on:
       - postgres
@@ -40,7 +43,7 @@ services:
       options:
         max-size: 10m
         max-file: "3"
-    volumes:
+    volumes: &volumes
       - ./dags:/opt/airflow/dags
       - ./plugins:/opt/airflow/plugins
       - ./scripts:/opt/airflow/scripts
@@ -56,7 +59,7 @@ services:
       timeout: 30s
       retries: 3
   scheduler:
-    image: apache/airflow:1.10.12
+    image: *image
     restart: always
     depends_on:
       - postgres
@@ -66,13 +69,7 @@ services:
       options:
         max-size: 10m
         max-file: "3"
-    volumes:
-      - ./dags:/opt/airflow/dags
-      - ./plugins:/opt/airflow/plugins
-      - ./scripts:/opt/airflow/scripts
-      - logs/:/opt/airflow/logs
-      - ./requirements.txt:/opt/airflow/requirements.txt
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
+    volumes: *volumes
     command: scheduler
     ports:
       - "8793:8793"


### PR DESCRIPTION
With new documentation in the README.
Based on the default Airflow docker image, instead of the weird puckel one.

Uses environment variables to setup the Airflow Connections that our DAGs depend on.