### PR TITLE
comment out execution_timeout - dag still fails due to timeout

### DIFF
--- a/dags/k8s_nci_db_update_summary.py
+++ b/dags/k8s_nci_db_update_summary.py
@@ -89,7 +89,7 @@ with dag:
         get_logs=True,
         is_delete_operator_pod=True,
         affinity=affinity,
-        execution_timeout=timedelta(days=1),
+        # execution_timeout=timedelta(days=1),
     )
 
     # Task complete


### PR DESCRIPTION
comment out execution_timeout - dag still fails due to timeout -needs  to evaluate its value again and enable this config