### PR TITLE
cleanup ancillary volume

### DIFF
--- a/dags/k8s_wagl_nrt_ancillary.py
+++ b/dags/k8s_wagl_nrt_ancillary.py
@@ -43,6 +43,15 @@ def brdf_doys(doy):
 
 SYNC_JOBS = [
     "date",
+    "echo garbage cleanup",
+    "mkdir -p /ancillary/granules/",
+    "mkdir -p /ancillary/output/",
+    "mkdir -p /ancillary/transfer/",
+    "mkdir -p /ancillary/upload/",
+    "find /ancillary/granules/ -type f -mtime +1 -delete",
+    "find /ancillary/output/ -type f -mtime +1 -delete",
+    "find /ancillary/transfer/ -type f -mtime +1 -delete",
+    "find /ancillary/upload/ -type f -mtime +1 -delete",
     "echo synching ozone",
     sync("s3://ga-sentinel/ancillary/lookup_tables/ozone/", "/ancillary/ozone"),
     "echo synching dsm",


### PR DESCRIPTION
- delete things that are more than 2 days old
- I still do not like this solution because it leaves empty folders, but the `find` command in our containers do not seem to support the `-empty` flag