### PR TITLE
Fix/prep for airflow 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install airflow and run pylint
         run: |
           pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]==1.10.14
+          pip install apache-airflow-backport-providers-ssh apache-airflow-backport-providers-sftp apache-airflow-backport-providers-cncf-kubernetes apache-airflow-backport-providers-amazon
           pip install pylint pylint-airflow
           pylint --load-plugins=pylint_airflow --disable=C,W --disable=similarities dags
       - name: setup airflow and run list_dags

--- a/dags/aws_check_dead_queues.py
+++ b/dags/aws_check_dead_queues.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from textwrap import dedent
 
 from airflow import DAG, AirflowException
-from airflow.providers.amazon.sensors.sqs import SQSHook
+from airflow.providers.amazon.aws.sensors.sqs import SQSHook
 from airflow.operators.python_operator import PythonOperator
 
 default_args = {

--- a/dags/aws_check_dead_queues.py
+++ b/dags/aws_check_dead_queues.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from textwrap import dedent
 
 from airflow import DAG, AirflowException
-from airflow.contrib.sensors.aws_sqs_sensor import SQSHook
+from airflow.providers.amazon.sensors.sqs import SQSHook
 from airflow.operators.python_operator import PythonOperator
 
 default_args = {

--- a/dags/github_metrics.py
+++ b/dags/github_metrics.py
@@ -23,7 +23,7 @@ import psycopg2
 import requests
 from airflow import DAG
 from airflow import secrets
-from airflow.contrib.hooks.ssh_hook import SSHHook
+from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator

--- a/dags/k8s_db_sync.py
+++ b/dags/k8s_db_sync.py
@@ -16,10 +16,10 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.sensors.s3_key_sensor import S3KeySensor
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.dummy_operator import DummyOperator
 

--- a/dags/k8s_dea_access_dataloader.py
+++ b/dags/k8s_dea_access_dataloader.py
@@ -35,7 +35,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 
 # Operators; we need this to operate!
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.operators.sensors import HttpSensor
 
 # [END import_module]

--- a/dags/k8s_index_fc_wo_c3.py
+++ b/dags/k8s_index_fc_wo_c3.py
@@ -10,7 +10,7 @@ and configuration installed.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.dummy_operator import DummyOperator
 

--- a/dags/k8s_index_fc_wo_c3_backlog.py
+++ b/dags/k8s_index_fc_wo_c3_backlog.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 import kubernetes.client.models as k8s
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.subdag_operator import SubDagOperator
 

--- a/dags/k8s_index_ls_c3.py
+++ b/dags/k8s_index_ls_c3.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.kubernetes.secret import Secret
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 DEFAULT_ARGS = {

--- a/dags/k8s_index_s2_s3.py
+++ b/dags/k8s_index_s2_s3.py
@@ -13,7 +13,7 @@ The DAG has to be parameterized with index date as below.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 
 

--- a/dags/k8s_nci_db_incremental_sync.py
+++ b/dags/k8s_nci_db_incremental_sync.py
@@ -20,7 +20,7 @@ and executes downstream task
 import pendulum
 from airflow import DAG
 from airflow.sensors.s3_key_sensor import S3KeySensor
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount

--- a/dags/k8s_nci_db_sync.py
+++ b/dags/k8s_nci_db_sync.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.sensors.s3_key_sensor import S3KeySensor
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount

--- a/dags/k8s_nci_db_update_summary.py
+++ b/dags/k8s_nci_db_update_summary.py
@@ -11,7 +11,7 @@ and [Resto](https://github.com/jjrom/resto).
 
 import pendulum
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.dummy_operator import DummyOperator
 from datetime import datetime, timedelta

--- a/dags/k8s_s3_orchestrate.py
+++ b/dags/k8s_s3_orchestrate.py
@@ -20,7 +20,7 @@ The DAG has to be parameterized with S3_Glob and Target product as below.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.dummy_operator import DummyOperator
 

--- a/dags/k8s_thredds_orchestrate.py
+++ b/dags/k8s_thredds_orchestrate.py
@@ -22,7 +22,7 @@ The lineage indexing strategy also has to be passed in.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from airflow.operators.dummy_operator import DummyOperator
 

--- a/dags/k8s_wagl_nrt.py
+++ b/dags/k8s_wagl_nrt.py
@@ -9,10 +9,9 @@ import json
 from airflow import DAG
 
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Resources
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.providers.amazon.sensors.sqs import SQSSensor
+from airflow.providers.amazon.aws.sensors.sqs import SQSSensor
 from airflow.providers.amazon.aws.hooks.sns import AwsSnsHook
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume

--- a/dags/k8s_wagl_nrt.py
+++ b/dags/k8s_wagl_nrt.py
@@ -8,17 +8,17 @@ import json
 
 from airflow import DAG
 
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow.contrib.operators.kubernetes_pod_operator import Resources
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Resources
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.contrib.sensors.aws_sqs_sensor import SQSSensor
-from airflow.contrib.hooks.aws_sns_hook import AwsSnsHook
+from airflow.providers.amazon.sensors.sqs import SQSSensor
+from airflow.providers.amazon.aws.hooks.sns import AwsSnsHook
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.hooks.S3_hook import S3Hook
-from airflow.contrib.hooks.aws_sqs_hook import SQSHook
+from airflow.providers.amazon.aws.hooks.sqs import SQSHook
 from airflow.utils.trigger_rule import TriggerRule
 
 import kubernetes.client.models as k8s

--- a/dags/k8s_wagl_nrt_ancillary.py
+++ b/dags/k8s_wagl_nrt_ancillary.py
@@ -4,7 +4,7 @@ Fetch wagl NRT ancillary.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume

--- a/dags/k8s_wagl_nrt_filter.py
+++ b/dags/k8s_wagl_nrt_filter.py
@@ -12,7 +12,7 @@ from airflow import configuration
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
-from airflow.providers.amazon.sensors.sqs import SQSSensor
+from airflow.providers.amazon.aws.sensors.sqs import SQSSensor
 from airflow.providers.amazon.aws.hooks.sqs import SQSHook
 
 

--- a/dags/k8s_wagl_nrt_filter.py
+++ b/dags/k8s_wagl_nrt_filter.py
@@ -12,8 +12,8 @@ from airflow import configuration
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
-from airflow.contrib.sensors.aws_sqs_sensor import SQSSensor
-from airflow.contrib.hooks.aws_sqs_hook import SQSHook
+from airflow.providers.amazon.sensors.sqs import SQSSensor
+from airflow.providers.amazon.aws.hooks.sqs import SQSHook
 
 
 AWS_CONN_ID = "wagl_nrt_manual"

--- a/dags/lpgs_qsub_jobs_report.py
+++ b/dags/lpgs_qsub_jobs_report.py
@@ -4,7 +4,7 @@ Another test DAG
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago

--- a/dags/nci_ard.py
+++ b/dags/nci_ard.py
@@ -9,7 +9,7 @@ The logs are written to NCI.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.dummy_operator import DummyOperator
 
 from sensors.pbs_job_complete_sensor import PBSJobSensor

--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -3,7 +3,7 @@
 
 """
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from datetime import datetime, timedelta
 
 default_args = {

--- a/dags/nci_build_dea_unstable_module.py
+++ b/dags/nci_build_dea_unstable_module.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 import pendulum
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.email_operator import EmailOperator
 
 local_tz = pendulum.timezone("Australia/Canberra")

--- a/dags/nci_build_env_module.py
+++ b/dags/nci_build_env_module.py
@@ -3,7 +3,7 @@
 
 """
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from datetime import datetime, timedelta
 
 default_args = {

--- a/dags/nci_c3_upload_s3.py
+++ b/dags/nci_c3_upload_s3.py
@@ -26,9 +26,9 @@ from textwrap import dedent
 
 import pendulum
 from airflow import DAG, configuration
-from airflow.contrib.hooks.aws_hook import AwsHook
-from airflow.contrib.operators.sftp_operator import SFTPOperator, SFTPOperation
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
+from airflow.providers.ssh.operators.ssh import SSHOperator
 
 local_tz = pendulum.timezone("Australia/Canberra")
 

--- a/dags/nci_c3_upload_s3.py
+++ b/dags/nci_c3_upload_s3.py
@@ -151,7 +151,7 @@ with dag:
             create_intermediate_dirs=True,
         )
         # Execute script to upload Landsat collection 3 data to s3 bucket
-        aws_hook = AwsHook(aws_conn_id=dag.default_args["aws_conn_id"])
+        aws_hook = AwsBaseHook(aws_conn_id=dag.default_args["aws_conn_id"], client_type='s3')
         execute_c3_to_s3_script = SSHOperator(
             task_id=f"execute_c3_to_s3_script_{product}",
             command=COMMON + RUN_UPLOAD_SCRIPT,

--- a/dags/nci_cog_and_upload.py
+++ b/dags/nci_cog_and_upload.py
@@ -26,8 +26,8 @@ from datetime import timedelta
 from textwrap import dedent
 
 from airflow import DAG, AirflowException
-from airflow.contrib.hooks.aws_hook import AwsHook
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.python_operator import ShortCircuitOperator
 from airflow.operators.sensors import ExternalTaskSensor
 

--- a/dags/nci_cog_and_upload.py
+++ b/dags/nci_cog_and_upload.py
@@ -231,7 +231,7 @@ with dag:
 
         )
 
-        aws_connection = AwsHook(aws_conn_id='dea_public_data_upload')
+        aws_connection = AwsBaseHook(aws_conn_id='dea_public_data_upload', client_type='s3')
         upload_to_s3 = SSHOperator(
             task_id=f'upload_to_s3_{product}',
             command=COMMON + dedent("""

--- a/dags/nci_common.py
+++ b/dags/nci_common.py
@@ -6,9 +6,9 @@ local_tz = pendulum.timezone("Australia/Canberra")
 
 c2_start_date = datetime(2020, 3, 12, tzinfo=local_tz)
 
-# “At 01:00 on Tuesday and Saturday.”
-# https://crontab.guru/#0_1_*_*_2,6
-c2_schedule_interval = "0 1 * * 2,6"
+# “At 01:00 on Tuesday, Thursday and Saturday.”
+# https://crontab.guru/#0_1_*_*_2,4,6
+c2_schedule_interval = "0 1 * * 2,4,6"
 
 c2_default_args = {
     'owner': 'Damien Ayers',

--- a/dags/nci_dataset_ingest.py
+++ b/dags/nci_dataset_ingest.py
@@ -14,7 +14,7 @@ This DAG executes everything using Gadi at the NCI.
 from textwrap import dedent
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.sensors.external_task_sensor import ExternalTaskSensor
 
 from nci_common import c2_schedule_interval, c2_default_args, DAYS

--- a/dags/nci_dataset_sync.py
+++ b/dags/nci_dataset_sync.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from sensors.pbs_job_complete_sensor import PBSJobSensor
 from nci_common import c2_default_args, c2_schedule_interval, MINUTES
 

--- a/dags/nci_db_backup.py
+++ b/dags/nci_db_backup.py
@@ -70,7 +70,7 @@ with DAG('nci_db_backup',
         """),
     )
 
-    aws_conn = AwsHook(aws_conn_id='aws_nci_db_backup')
+    aws_conn = AwsBaseHook(aws_conn_id='aws_nci_db_backup', client_type='s3')
     upload_to_s3 = SSHOperator(
         task_id='upload_to_s3',
         params=dict(aws_conn=aws_conn),

--- a/dags/nci_db_backup.py
+++ b/dags/nci_db_backup.py
@@ -7,8 +7,8 @@ from textwrap import dedent
 
 import pendulum
 from airflow import DAG
-from airflow.contrib.hooks.aws_hook import AwsHook
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
 
 local_tz = pendulum.timezone("Australia/Canberra")
 

--- a/dags/nci_db_incremental_csvs.py
+++ b/dags/nci_db_incremental_csvs.py
@@ -12,8 +12,8 @@ This DAG should be idempotent, ie. running repeatedly is safe.
 from textwrap import dedent
 
 from airflow import DAG
-from airflow.contrib.hooks.aws_hook import AwsHook
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
 
 from datetime import datetime, timedelta
 

--- a/dags/nci_db_incremental_csvs.py
+++ b/dags/nci_db_incremental_csvs.py
@@ -98,7 +98,7 @@ with DAG(
     )
 
     # Grab credentials from an Airflow Connection
-    aws_conn = AwsHook(aws_conn_id="aws_nci_db_backup")
+    aws_conn = AwsBaseHook(aws_conn_id='aws_nci_db_backup', client_type='s3')
 
     upload_change_csvs_to_s3 = SSHOperator(
         task_id="upload_change_csvs_to_s3",

--- a/dags/nci_fractional_cover.py
+++ b/dags/nci_fractional_cover.py
@@ -10,7 +10,7 @@
 from textwrap import dedent
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.sensors.external_task_sensor import ExternalTaskSensor
 from nci_common import c2_schedule_interval, c2_default_args, DAYS
 from operators.ssh_operators import ShortCircuitSSHOperator

--- a/dags/nci_index_s2ard_simple.py
+++ b/dags/nci_index_s2ard_simple.py
@@ -20,7 +20,7 @@ from textwrap import dedent
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 
 default_args = {
     'owner': 'Damien Ayers',

--- a/dags/nci_s2_upload_s3.py
+++ b/dags/nci_s2_upload_s3.py
@@ -15,9 +15,9 @@ from textwrap import dedent
 
 import pendulum
 from airflow import DAG, configuration
-from airflow.contrib.hooks.aws_hook import AwsHook
-from airflow.contrib.operators.sftp_operator import SFTPOperator, SFTPOperation
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
+from airflow.providers.ssh.operators.ssh import SSHOperator
 
 from nci_common import HOURS, MINUTES
 

--- a/dags/nci_s2_upload_s3.py
+++ b/dags/nci_s2_upload_s3.py
@@ -102,7 +102,7 @@ with dag:
     )
 
     # Execute script to upload sentinel-2 data to s3 bucket
-    aws_hook = AwsHook(aws_conn_id=dag.default_args['aws_conn_id'])
+    aws_hook = AwsBaseHook(aws_conn_id=dag.default_args['aws_conn_id'], client_type='s3')
     execute_upload = SSHOperator(
         task_id='execute_upload',
         # language="Shell Script"

--- a/dags/nci_wofs.py
+++ b/dags/nci_wofs.py
@@ -11,7 +11,7 @@
 from textwrap import dedent
 
 from airflow import DAG
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.sensors.external_task_sensor import ExternalTaskSensor
 from nci_common import c2_default_args, c2_schedule_interval, HOURS, MINUTES, DAYS
 from operators.ssh_operators import ShortCircuitSSHOperator

--- a/dags/sqs_processing_workflow/sentinel_2_nrt_archive.py
+++ b/dags/sqs_processing_workflow/sentinel_2_nrt_archive.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.kubernetes.secret import Secret
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
 from textwrap import dedent
 

--- a/dags/sqs_processing_workflow/sentinel_2_nrt_batch_indexing.py
+++ b/dags/sqs_processing_workflow/sentinel_2_nrt_batch_indexing.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.kubernetes.secret import Secret
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
 from textwrap import dedent
 

--- a/dags/sqs_processing_workflow/sentinel_2_nrt_streamline_indexing.py
+++ b/dags/sqs_processing_workflow/sentinel_2_nrt_streamline_indexing.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.kubernetes.secret import Secret
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
 from sqs_processing_workflow.images import INDEXER_IMAGE
 from env_var.infra import (

--- a/dags/sqs_processing_workflow/subdag_explorer_summary.py
+++ b/dags/sqs_processing_workflow/subdag_explorer_summary.py
@@ -5,7 +5,7 @@ This subdag can be called by other dags
 
 from airflow import DAG
 from textwrap import dedent
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 from sqs_processing_workflow.env_cfg import INDEXING_PRODUCTS, NODE_AFFINITY
 from sqs_processing_workflow.images import EXPLORER_IMAGE

--- a/dags/sqs_processing_workflow/subdag_ows_views.py
+++ b/dags/sqs_processing_workflow/subdag_ows_views.py
@@ -4,7 +4,7 @@
 from airflow import DAG
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.kubernetes.secret import Secret
 
 from textwrap import dedent

--- a/dags/testdag.py
+++ b/dags/testdag.py
@@ -6,7 +6,7 @@ A bit of a playground for new development.
 from airflow import DAG
 from datetime import datetime
 
-from airflow.contrib.operators.ssh_operator import SSHOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.email_operator import EmailOperator
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         max-size: 10m
         max-file: "3"
   setup-airflow:
-    image: &image apache/airflow:1.10.11
+    image: &image apache/airflow:1.10.14
     depends_on:
       - postgres
     environment: &env

--- a/plugins/dea_airflow_common/ssh.py
+++ b/plugins/dea_airflow_common/ssh.py
@@ -8,7 +8,7 @@ TODO: And then try to push it upstream as it's useful functionality
 from select import select
 
 from airflow import AirflowException
-from airflow.contrib.hooks.ssh_hook import SSHHook
+from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.utils.decorators import apply_defaults
 
 

--- a/plugins/operators/ssh_operators.py
+++ b/plugins/operators/ssh_operators.py
@@ -6,8 +6,8 @@ import os.path
 from io import StringIO
 
 from airflow import AirflowException
-from airflow.contrib.hooks.ssh_hook import SSHHook
-from airflow.contrib.operators.sftp_operator import _make_intermediate_dirs
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.sftp.operators.sftp import _make_intermediate_dirs
 from airflow.models import BaseOperator, SkipMixin
 from airflow.utils.decorators import apply_defaults
 


### PR DESCRIPTION
This addresses at least some of the Airflow 2 required changes in our DAGs. See #158 for more context.

```
pip install apache-airflow-upgrade-check
airflow upgrade_check -i UndefinedJinjaVariablesRule
```

Unfortunately, the `upgrade_check` tool doesn't handle fixed cases, so doesn't give us an easy list to work through as everything that has been fixed still shows in the list. :(


Does our airflow deployment include the `apache-airflow-backport-providers-*` packages?