### PR TITLE
Download C3 Derivatives to the NCI

### DIFF
--- a/dags/nci_c3_download_derivs.py
+++ b/dags/nci_c3_download_derivs.py
@@ -11,51 +11,83 @@ from airflow.contrib.operators.ssh_operator import SSHOperator
 
 
 dag = DAG(
-    'nci_c3_download_derivs',
+    "nci_c3_download_derivs",
     doc_md=__doc__,
     catchup=False,
-    tags=['nci', 'landsat_c3'],
-    default_view='tree',
+    tags=["nci", "landsat_c3"],
+    default_view="tree",
+    default_args=dict(
+        do_xcom_push=False,
+        ssh_conn_id='lpgs_gadi',
+    )
 )
 
 with dag:
 
-
-    # Options:
+    # Need to decide between two options:
     # 1. Use s5cmd, save output of transferred files, index them.
     #
     # 2. Save inventory from Athena/raw. Save NCI files from DB. Compare
 
-    setup = SSHOperator(task_id='setup',
-                        ssh_conn_id='lpgs_gadi',
-                        do_xcom_push=False,
-                        command=dedent("""
-                        mkdir -p /g/data/v10/work/c3_download_derivs/{{ ts_nodash }}
+    setup = SSHOperator(
+        task_id="setup",
+        command=dedent(
+            """
+            mkdir -p /g/data/v10/work/c3_download_derivs/{{ ts_nodash }}
+            """
+        ),
+    )
 
-                        """))
+    # Sync WOfS directory using a Gadi Data Mover node
+    sync_wofs = SSHOperator(
+        task_id="sync_wofs",
+        remote_host="gadi-dm.nci.org.au",
+        command=dedent(
+            """
+            cd /g/data/jw04/ga/ga_ls_wo_3
+            time ~/bin/s5cmd --stat cp --if-size-differ 's3://dea-public-data/derivative/ga_ls_wo_3/*' ." > /g/data/v10/work/c3_download_derivs/{{ts_nodash}}/ga_ls_wo_3.download.log
+            """
+        ),
+    )
 
-    # Sync WOfS directory
-    sync_wofs = SSHOperator(task_id="sync_wofs",
-                            ssh_conn_id="lpgs_gadi",
-                            remote_host="gadi-dm.nci.org.au",
-                            do_xcom_push=False,
-                            command=dedent("""
-cd /g/data/jw04/ga/ga_ls_wo_3
-time ~/bin/s5cmd --stat cp --if-size-differ 's3://dea-public-data/derivative/ga_ls_wo_3/*' ." > /g/data/v10/work/c3_download_derivs/{{ts_nodash}}/ga_ls_wo_3.download.log
-    """))
+    # Sync FC directory using a Gadi Data Mover node
+    sync_fc = SSHOperator(
+        task_id="sync_fc",
+        remote_host="gadi-dm.nci.org.au",
+        command=dedent(
+            """
+            cd /g/data/jw04/ga/ga_ls_fc_3
+            time ~/bin/s5cmd --stat cp --if-size-differ 's3://dea-public-data/derivative/ga_ls_fc_3/*' ." > /g/data/v10/work/c3_download_derivs/{{ts_nodash}}/ga_ls_fc_3.download.log
+            """
+        ),
+    )
 
-    # Sync FC directory
-    sync_fc = SSHOperator(task_id="sync_fc",
-                            ssh_conn_id="lpgs_gadi",
-                            remote_host="gadi-dm.nci.org.au",
-                            do_xcom_push=False,
-                            command="""""")
+    index_wofs = SSHOperator(
+        task_id="index_wofs",
+        command=dedent(
+            """
+            module load dea
+            cd /g/data/v10/work/c3_download_derivs/{{ts_nodash}}
 
+            awk '/odc-metadata.yaml/ {print "/g/data/jw04/ga/ga_ls_wo_3/" $0}' ga_ls_wo_3.download.log  | \
+            xargs -P 4 datacube -v dataset add --no-verify-lineage --product ga_ls_wo_3
+        """
+        ),
+    )
 
-    index_wofs = SSHOperator()
+    index_fc = SSHOperator(
+        task_id="index_fc",
+        command=dedent(
+            """
+            module load dea
+            cd /g/data/v10/work/c3_download_derivs/{{ts_nodash}}
 
+            awk '/odc-metadata.yaml/ {print "/g/data/jw04/ga/ga_ls_fc_3/" $0}' ga_ls_fc_3.download.log  | \
+            xargs -P 4 datacube -v dataset add --no-verify-lineage --product ga_ls_fc_3
+            """
+        ),
+    )
 
-    index_fc = SSHOperator()
-
+    setup >> [sync_fc, sync_wofs]
     sync_wofs >> index_wofs
     sync_fc >> index_fc

--- a/dags/nci_c3_download_derivs.py
+++ b/dags/nci_c3_download_derivs.py
@@ -12,7 +12,7 @@ from airflow.contrib.operators.ssh_operator import SSHOperator
 
 dag = DAG(
     'nci_c3_download_derivs',
-    mod_md=__doc__,
+    doc_md=__doc__,
     catchup=False,
     tags=['nci', 'landsat_c3'],
     default_view='tree',
@@ -26,14 +26,36 @@ with dag:
     #
     # 2. Save inventory from Athena/raw. Save NCI files from DB. Compare
 
+    setup = SSHOperator(task_id='setup',
+                        ssh_conn_id='lpgs_gadi',
+                        do_xcom_push=False,
+                        command=dedent("""
+                        mkdir -p /g/data/v10/work/c3_download_derivs/{{ ts_nodash }}
+
+                        """))
+
     # Sync WOfS directory
-    sync_wofs = SSHOperator()
+    sync_wofs = SSHOperator(task_id="sync_wofs",
+                            ssh_conn_id="lpgs_gadi",
+                            remote_host="gadi-dm.nci.org.au",
+                            do_xcom_push=False,
+                            command=dedent("""
+cd /g/data/jw04/ga/ga_ls_wo_3
+time ~/bin/s5cmd --stat cp --if-size-differ 's3://dea-public-data/derivative/ga_ls_wo_3/*' ." > /g/data/v10/work/c3_download_derivs/{{ts_nodash}}/ga_ls_wo_3.download.log
+    """))
 
     # Sync FC directory
-    sync_fc = SSHOperator()
+    sync_fc = SSHOperator(task_id="sync_fc",
+                            ssh_conn_id="lpgs_gadi",
+                            remote_host="gadi-dm.nci.org.au",
+                            do_xcom_push=False,
+                            command="""""")
 
 
     index_wofs = SSHOperator()
 
 
     index_fc = SSHOperator()
+
+    sync_wofs >> index_wofs
+    sync_fc >> index_fc


### PR DESCRIPTION
Uses:
- `s5cmd` to do a fast, full, download of the entire S3 folder structure
- Records the new files that are downloaded, and indexes them into the database

Shortcomings:
- Doesn't handle archived/deleted datasets, yet
- Not idempotent/partitioned by date, it performs a full sync every time it runs
- Syncs based on S3 Listings, not a database index or S3 Inventory. Less efficient, more costly, but plenty fast enough and not actually expensive.