### PR TITLE
#207 Create x3 Schema migration DAG's

### DIFF
--- a/dags/k8s_aws_db_migrate_schema copy.py
+++ b/dags/k8s_aws_db_migrate_schema copy.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+"""
+### DEA NCI dev database - migrate schema
+
+DAG to manually migrate schema for NCI DB when new version of explorer is
+deployed.
+
+"""
+
+import pendulum
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.kubernetes.secret import Secret
+from airflow.operators.dummy_operator import DummyOperator
+from datetime import datetime, timedelta
+
+local_tz = pendulum.timezone("Australia/Canberra")
+
+# Templated DAG arguments
+DB_HOSTNAME = "db-writer"
+
+DEFAULT_ARGS = {
+    "owner": "Tisham Dhar",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 10, 3, tzinfo=local_tz),
+    "email": ["tisham.dhar@ga.gov.au"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "env_vars": {
+        "AWS_DEFAULT_REGION": "ap-southeast-2",
+        "DB_HOSTNAME": DB_HOSTNAME,
+        "DB_PORT": "5432",
+    },
+    # Use K8S secrets to send DB Creds
+    # Lift secrets into environment variables for datacube database connectivity
+    # Use this db-users to run cubedash update-summary
+    "secrets": [
+        Secret("env", "DB_DATABASE", "explorer-admin", "database-name"),
+        Secret("env", "DB_USERNAME", "explorer-admin", "postgres-username"),
+        Secret("env", "DB_PASSWORD", "explorer-admin", "postgres-password"),
+    ],
+}
+
+EXPLORER_IMAGE = "opendatacube/explorer:2.4.3-65-ge372da5"
+
+dag = DAG(
+    "k8s_aws_db_migrate_schema",
+    doc_md=__doc__,
+    default_args=DEFAULT_ARGS,
+    catchup=False,
+    concurrency=1,
+    max_active_runs=1,
+    tags=["k8s"],
+    schedule_interval=None,    # Fully manual migrations
+)
+
+affinity = {
+    "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [{
+                "matchExpressions": [{
+                    "key": "nodetype",
+                    "operator": "In",
+                    "values": [
+                        "ondemand",
+                    ]
+                }]
+            }]
+        }
+    }
+}
+
+with dag:
+    START = DummyOperator(task_id="nci-db-update-schema")
+
+    # Run update summary
+    UPDATE_SCHEMA = KubernetesPodOperator(
+        namespace="processing",
+        image=EXPLORER_IMAGE,
+        cmds=["cubedash-gen"],
+        arguments=["--init", "-v"],
+        labels={"step": "update-schema"},
+        name="update-schema",
+        task_id="update-schema",
+        get_logs=True,
+        is_delete_operator_pod=True,
+        affinity=affinity,
+        # execution_timeout=timedelta(days=1),
+    )
+
+    # Task complete
+    COMPLETE = DummyOperator(task_id="done")
+
+
+    START >> UPDATE_SCHEMA
+    UPDATE_SCHEMA >> COMPLETE

--- a/dags/k8s_nci_db_migrate_schema.py
+++ b/dags/k8s_nci_db_migrate_schema.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+"""
+### DEA NCI dev database - migrate schema
+
+DAG to manually migrate schema for NCI DB when new version of explorer is
+deployed.
+
+"""
+
+import pendulum
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.kubernetes.secret import Secret
+from airflow.operators.dummy_operator import DummyOperator
+from datetime import datetime, timedelta
+
+local_tz = pendulum.timezone("Australia/Canberra")
+
+# Templated DAG arguments
+DB_HOSTNAME = "db-writer"
+
+DEFAULT_ARGS = {
+    "owner": "Tisham Dhar",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 10, 3, tzinfo=local_tz),
+    "email": ["tisham.dhar@ga.gov.au"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "env_vars": {
+        "AWS_DEFAULT_REGION": "ap-southeast-2",
+        "DB_HOSTNAME": DB_HOSTNAME,
+        "DB_PORT": "5432",
+    },
+    # Use K8S secrets to send DB Creds
+    # Lift secrets into environment variables for datacube database connectivity
+    # Use this db-users to run cubedash update-summary
+    "secrets": [
+        Secret("env", "DB_DATABASE", "explorer-nci-admin", "database-name"),
+        Secret("env", "DB_USERNAME", "explorer-nci-admin", "postgres-username"),
+        Secret("env", "DB_PASSWORD", "explorer-nci-admin", "postgres-password"),
+    ],
+}
+
+EXPLORER_IMAGE = "opendatacube/explorer:2.4.3-65-ge372da5"
+
+dag = DAG(
+    "k8s_nci_db_migrate_schema",
+    doc_md=__doc__,
+    default_args=DEFAULT_ARGS,
+    catchup=False,
+    concurrency=1,
+    max_active_runs=1,
+    tags=["k8s"],
+    schedule_interval=None,    # Fully manual migrations
+)
+
+affinity = {
+    "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [{
+                "matchExpressions": [{
+                    "key": "nodetype",
+                    "operator": "In",
+                    "values": [
+                        "ondemand",
+                    ]
+                }]
+            }]
+        }
+    }
+}
+
+with dag:
+    START = DummyOperator(task_id="nci-db-update-schema")
+
+    # Run update summary
+    UPDATE_SCHEMA = KubernetesPodOperator(
+        namespace="processing",
+        image=EXPLORER_IMAGE,
+        cmds=["cubedash-gen"],
+        arguments=["--init", "-v"],
+        labels={"step": "update-schema"},
+        name="update-schema",
+        task_id="update-schema",
+        get_logs=True,
+        is_delete_operator_pod=True,
+        affinity=affinity,
+        # execution_timeout=timedelta(days=1),
+    )
+
+    # Task complete
+    COMPLETE = DummyOperator(task_id="done")
+
+
+    START >> UPDATE_SCHEMA
+    UPDATE_SCHEMA >> COMPLETE

--- a/dags/k8s_sandbox_db_migrate_schema.py
+++ b/dags/k8s_sandbox_db_migrate_schema.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+"""
+### DEA NCI dev database - migrate schema
+
+DAG to manually migrate schema for NCI DB when new version of explorer is
+deployed.
+
+"""
+
+import pendulum
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.kubernetes.secret import Secret
+from airflow.operators.dummy_operator import DummyOperator
+from datetime import datetime, timedelta
+
+local_tz = pendulum.timezone("Australia/Canberra")
+
+# Templated DAG arguments
+DB_HOSTNAME = "db-writer"
+
+DEFAULT_ARGS = {
+    "owner": "Tisham Dhar",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 10, 3, tzinfo=local_tz),
+    "email": ["tisham.dhar@ga.gov.au"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "env_vars": {
+        "AWS_DEFAULT_REGION": "ap-southeast-2",
+        "DB_HOSTNAME": DB_HOSTNAME,
+        "DB_PORT": "5432",
+    },
+    # Use K8S secrets to send DB Creds
+    # Lift secrets into environment variables for datacube database connectivity
+    # Use this db-users to run cubedash update-summary
+    "secrets": [
+        Secret("env", "DB_DATABASE", "explorer-admin", "database-name"),
+        Secret("env", "DB_USERNAME", "explorer-admin", "postgres-username"),
+        Secret("env", "DB_PASSWORD", "explorer-admin", "postgres-password"),
+    ],
+}
+
+EXPLORER_IMAGE = "opendatacube/explorer:2.4.3-65-ge372da5"
+
+dag = DAG(
+    "k8s_sandbox_db_migrate_schema",
+    doc_md=__doc__,
+    default_args=DEFAULT_ARGS,
+    catchup=False,
+    concurrency=1,
+    max_active_runs=1,
+    tags=["k8s"],
+    schedule_interval=None,    # Fully manual migrations
+)
+
+affinity = {
+    "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [{
+                "matchExpressions": [{
+                    "key": "nodetype",
+                    "operator": "In",
+                    "values": [
+                        "ondemand",
+                    ]
+                }]
+            }]
+        }
+    }
+}
+
+with dag:
+    START = DummyOperator(task_id="nci-db-update-schema")
+
+    # Run update summary
+    UPDATE_SCHEMA = KubernetesPodOperator(
+        namespace="processing",
+        image=EXPLORER_IMAGE,
+        cmds=["cubedash-gen"],
+        arguments=["--init", "-v"],
+        labels={"step": "update-schema"},
+        name="update-schema",
+        task_id="update-schema",
+        get_logs=True,
+        is_delete_operator_pod=True,
+        affinity=affinity,
+        # execution_timeout=timedelta(days=1),
+    )
+
+    # Task complete
+    COMPLETE = DummyOperator(task_id="done")
+
+
+    START >> UPDATE_SCHEMA
+    UPDATE_SCHEMA >> COMPLETE


### PR DESCRIPTION
This PR creates x3 DAG's to apply schema migrations for a given latest version of an Explorer using the `cubedash-gen --init -v` command. The 3 ODC instances in this cluster are :
- AWS S3 + Sandbox
- AWS S3 + OWS
- NCI RDS Copy