### PR TITLE
Sentinel 2 NBART S3 Sync

### DIFF
--- a/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
+++ b/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
@@ -1,0 +1,119 @@
+"""
+# Sentinel-2 data routine sync to S3 bucket
+This DAG runs tasks on Gadi at the NCI. This DAG routinely sync Sentinel-2
+data from NCI to AWS S3 bucket. It:
+ * Uploads `Sentinel-2 to S3 rolling` script to NCI work folder.
+ * Finds all the new data added since the last run, saves them into a txt file
+ * Executes the upload script to upload the data and mangle and upload the metadata file to S3
+"""
+from datetime import datetime, timedelta
+from pathlib import Path
+from textwrap import dedent
+
+import pendulum
+from airflow import DAG, configuration
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
+from airflow.providers.ssh.operators.ssh import SSHOperator
+
+HOURS = 60 * 60
+MINUTES = 60
+DAYS = HOURS * 24
+
+local_tz = pendulum.timezone("Australia/Canberra")
+
+# language="Shell Script"
+COMMON = dedent("""
+        {% set work_dir = '/home/547/kr4383/work/s2_nbart_rolling_archive/' + ds  -%}
+        mkdir -p {{work_dir}}
+        cd {{ work_dir }}
+        # echo on and exit on fail
+        set -eu
+        # Load the latest stable DEA module
+        module use /g/data/v10/public/modules/modulefiles
+        module load dea
+        # Be verbose and echo what we run
+        set -x
+""")
+
+default_args = {
+    'owner': 'Kieran Ricardo',
+    'start_date': datetime(2021, 3, 1, tzinfo=local_tz),
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+    'email_on_failure': False,
+    'email': 'kieran.ricardo@ga.gov.au',
+    'ssh_conn_id': 'lpgs_gadi',
+    'aws_conn_id': 'dea_public_data_upload',
+}
+
+dag = DAG(
+    'nbart_nci_s2_upload_s3_v2',
+    doc_md=__doc__,
+    default_args=default_args,
+    catchup=True,
+    schedule_interval='@daily',
+    max_active_runs=4,
+    default_view='tree',
+    tags=['nci', 'sentinel_2'],
+)
+
+with dag:
+    # Uploading s2_to_s3_rolling.py script to NCI
+    upload_uploader_script = SFTPOperator(
+        task_id="upload_uploader_script",
+        local_filepath=str(Path(configuration.get('core', 'dags_folder')) / "sentinel_2_nbart/upload_s2_nbart.py"),
+        remote_filepath="/home/547/kr4383/work/s2_nbart_rolling_archive/{{ds}}/upload_s2_nbart.py",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+    # language="Shell Script"
+    generate_list = SSHOperator(
+        task_id='generate_list_of_s2_to_upload',
+        # language="Shell Script"
+        command=COMMON + dedent("""
+
+            rm -f granule_ids.txt  # In case we've been run before
+            for product_name in s2a_ard_granule s2b_ard_granule; do
+                echo Searching for $product_name datasets.
+            psql --variable=ON_ERROR_STOP=1 --csv --quiet --tuples-only --no-psqlrc \
+                 -h dea-db.nci.org.au datacube <<EOF >> granule_ids.txt
+            SELECT 
+                    substring(ds.metadata#>>'{extent,center_dt}' for 10) || '/' 
+                    || replace(ds.metadata#>>'{tile_id}', 'L1C', 'ARD')
+                FROM agdc.dataset ds
+                INNER JOIN agdc.dataset_type dst ON ds.dataset_type_ref = dst.id
+                INNER JOIN agdc.dataset_location dsl ON ds.id = dsl.dataset_ref
+                WHERE dst.name='$product_name'
+                  AND ds.added BETWEEN '{{ prev_execution_date }}' AND '{{ execution_date }}';
+            EOF
+            done
+            echo -n Num Datasets to upload: 
+            wc -l granule_ids.txt
+
+        """),
+        remote_host='gadi-dm.nci.org.au',
+        timeout=20 * MINUTES,
+    )
+
+    # Execute script to upload sentinel-2 data to s3 bucket
+    aws_hook = AwsBaseHook(
+        aws_conn_id=dag.default_args['aws_conn_id'],
+        client_type="s3",
+    )
+
+    execute_upload = SSHOperator(
+        task_id='execute_upload',
+        # language="Shell Script"
+        command=dedent(COMMON + """
+            {% set aws_creds = params.aws_hook.get_credentials() -%}
+            # Export AWS Access key/secret from Airflow connection module
+            export AWS_ACCESS_KEY_ID={{aws_creds.access_key}}
+            export AWS_SECRET_ACCESS_KEY={{aws_creds.secret_key}}
+            python3 '{{ work_dir }}/upload_s2_nbart.py' granule_ids.txt
+        """),
+        remote_host='gadi-dm.nci.org.au',
+        params={'aws_hook': aws_hook},
+        timeout=10 * HOURS,
+    )
+    [upload_uploader_script, generate_list] >> execute_upload

--- a/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
+++ b/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
@@ -85,7 +85,7 @@ with dag:
                 INNER JOIN agdc.dataset_type dst ON ds.dataset_type_ref = dst.id
                 INNER JOIN agdc.dataset_location dsl ON ds.id = dsl.dataset_ref
                 WHERE dst.name='$product_name'
-                  AND ds.added BETWEEN '{{ prev_execution_date }}' AND '{{ execution_date }}';
+                  AND ds.added BETWEEN '{{ execution_date.subtract(days=1) }}' AND '{{ execution_date }}';
             EOF
             done
             echo -n Num Datasets to upload: 

--- a/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
+++ b/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
@@ -85,7 +85,7 @@ with dag:
                 INNER JOIN agdc.dataset_type dst ON ds.dataset_type_ref = dst.id
                 INNER JOIN agdc.dataset_location dsl ON ds.id = dsl.dataset_ref
                 WHERE dst.name='$product_name'
-                  AND ds.added BETWEEN '{{ execution_date.subtract(days=1) }}' AND '{{ execution_date }}';
+                  AND ds.added BETWEEN '{{ prev_execution_date }}' AND '{{ execution_date.add(days=1) }}';
             EOF
             done
             echo -n Num Datasets to upload: 

--- a/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
+++ b/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
@@ -24,7 +24,7 @@ local_tz = pendulum.timezone("Australia/Canberra")
 
 # language="Shell Script"
 COMMON = dedent("""
-        {% set work_dir = '/home/547/kr4383/work/s2_nbart_rolling_archive/' + ds  -%}
+        {% set work_dir = '/g/data/v10/work/s2_nbart_rolling_archive/' + ds  -%}
         mkdir -p {{work_dir}}
         cd {{ work_dir }}
         # echo on and exit on fail
@@ -63,7 +63,7 @@ with dag:
     upload_uploader_script = SFTPOperator(
         task_id="upload_uploader_script",
         local_filepath=str(Path(configuration.get('core', 'dags_folder')) / "sentinel_2_nbart/upload_s2_nbart.py"),
-        remote_filepath="/home/547/kr4383/work/s2_nbart_rolling_archive/{{ds}}/upload_s2_nbart.py",
+        remote_filepath="/g/data/v10/work/s2_nbart_rolling_archive/{{ds}}/upload_s2_nbart.py",
         operation=SFTPOperation.PUT,
         create_intermediate_dirs=True
     )

--- a/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
+++ b/dags/sentinel_2_nbart/nbart_nci_s2_upload_s3.py
@@ -12,9 +12,9 @@ from textwrap import dedent
 
 import pendulum
 from airflow import DAG, configuration
-from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
-from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.contrib.operators.sftp_operator import SFTPOperator, SFTPOperation
+from airflow.contrib.operators.ssh_operator import SSHOperator
 
 HOURS = 60 * 60
 MINUTES = 60
@@ -97,10 +97,7 @@ with dag:
     )
 
     # Execute script to upload sentinel-2 data to s3 bucket
-    aws_hook = AwsBaseHook(
-        aws_conn_id=dag.default_args['aws_conn_id'],
-        client_type="s3",
-    )
+    aws_hook = AwsHook(aws_conn_id=dag.default_args['aws_conn_id'])
 
     execute_upload = SSHOperator(
         task_id='execute_upload',

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -4,7 +4,6 @@ Script to sync Sentinel-2 data from NCI to AWS S3 bucket
 """
 
 import logging
-import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -23,7 +22,6 @@ import click
 import yaml
 from odc.aws import s3_client
 from tqdm import tqdm
-from eodatasets3 import serialise
 from eodatasets3.stac import to_stac_item
 from eodatasets3.model import (
     DatasetDoc,
@@ -36,10 +34,6 @@ import rasterio
 from eodatasets3 import serialise, validate, images, documents
 from rasterio import DatasetReader
 from shapely.geometry.polygon import Polygon
-# padding
-# skip
-# read bands: 16:42.37
-# read metadata: 0:50.63
 
 NCI_DIR = '/g/data/if87/datacube/002/S2_MSI_ARD/packaged'
 S3_PATH = 'L2/sentinel-2-nbart/S2MSIARD_NBART'

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Script to sync Sentinel-2 data from NCI to AWS S3 bucket
+"""
+
+import logging
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures._base import as_completed
+from odc.aws import s3_dump
+from pathlib import Path
+import os
+import json
+import boto3
+from eodatasets3 import DatasetAssembler
+from eodatasets3.scripts.tostac import json_fallback
+import datetime
+
+import click
+import yaml
+from odc.aws import s3_client
+from tqdm import tqdm
+from eodatasets3 import serialise
+from eodatasets3.stac import to_stac_item
+from eodatasets3.model import (
+    DatasetDoc,
+    ProductDoc,
+    AccessoryDoc,
+    Location,
+)
+
+NCI_DIR = '/g/data/if87/datacube/002/S2_MSI_ARD/packaged'
+S3_PATH = 'L2/sentinel-2-nbart/S2MSIARD_NBART'
+S3_BUCKET = 'dea-public-data-dev'
+WORK_DIR = Path('/home/547/kr4383/work/s2_nbart_rolling_archive')
+
+S3 = None
+
+_LOG = logging.getLogger()
+
+
+def setup_logging():
+    """Log to stdout (via TQDM if running interactively) as well as into a file."""
+    _LOG.setLevel(logging.INFO)
+    if sys.stdout.isatty():
+        c_handler = TqdmLoggingHandler()
+    else:
+        c_handler = logging.StreamHandler()
+    f_handler = logging.FileHandler('s3_uploads.log')
+    c_handler.setLevel(logging.INFO)
+    f_handler.setLevel(logging.INFO)
+
+    # Create formatters and add it to handlers
+    # c_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    c_handler.setFormatter(formatter)
+    f_handler.setFormatter(formatter)
+
+    # Add handlers to the logger
+    _LOG.addHandler(f_handler)
+    _LOG.addHandler(c_handler)
+
+
+@click.command()
+@click.argument('granule_ids', type=click.File('r'))
+@click.option('--workers', type=int, default=10)
+def main(granule_ids, workers):
+    """
+    Script to sync Sentinel-2 data from NCI to AWS S3 bucket
+    Pass in a file containing destination S3 urls that need to be uploaded.
+    """
+    setup_logging()
+
+    global S3
+    S3 = s3_client()
+    granule_ids = [granule_id.strip() for granule_id in granule_ids.readlines()]
+
+    _LOG.info(f"{len(granule_ids)} datasets to upload.")
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(upload_dataset, granule_id) for granule_id in granule_ids]
+
+        for future in tqdm(as_completed(futures), total=len(granule_ids), unit='datasets', disable=None):
+            _LOG.info(f"Completed uploaded: {future.result()}")
+
+
+def upload_dataset(granule_id):
+
+    upload_dataset_without_yaml(granule_id)
+    stac = upload_metadata(granule_id)
+    send_stac_sns(stac)
+
+
+def upload_dataset_without_yaml(granule_id):
+    """
+    Run AWS sync command to sync granules to S3 bucket
+    :param granule_id: name of the granule
+    :param _s3_bucket: name of the s3 bucket
+    """
+    local_path = Path(NCI_DIR) / granule_id
+    s3_path = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}"
+
+    # Remove any data that shouldn't be there and exclude the metadata and NBAR
+    command = f"aws s3 sync {local_path} {s3_path} " \
+              "--only-show-errors " \
+              "--delete " \
+              "--exclude NBAR/* " \
+              "--exclude ARD-METADATA.yaml"
+
+    try:
+        subprocess.run(command, shell=True, check=True, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        _LOG.info(f"Upload failed, stdout: {e.stdout}, stderr: {e.stderr}")
+        raise e
+
+
+def upload_metadata(granule_id):
+    """
+    Creates and uploads metadata in stac and eo3 formats.
+    :param granule_id: the id of the granule in format 'date/tile_id'
+    :return: serialized stac metadata
+    """
+
+    local_path = Path(NCI_DIR) / granule_id
+
+    s3_path = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/"
+    s3_path_eo3 = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/eo3-ARD-METADATA.yaml"
+    s3_path_stac = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/stac-ARD-METADATA.json"
+
+    eo3 = create_eo3(local_path)
+    stac = to_stac_item(
+        eo3,
+        stac_item_destination_url=s3_path_stac,
+        odc_dataset_metadata_url=s3_path_eo3,
+        dataset_location=s3_path,
+    )
+    stac = json.dumps(stac, default=json_fallback, indent=4)
+
+    s3_dump(yaml.safe_dump(serialise.to_doc(eo3), default_flow_style=False), s3_path_eo3, S3)
+    s3_dump(stac, s3_path_stac, S3)
+
+    return stac
+
+
+def send_stac_sns(stac):
+    """
+    Sends stac metadata as an SNS message
+    :param stac: serialized stac metadata
+    """
+
+    session = boto3.session.Session()
+    resource = session.client('sns', region_name='ap-southeast-2')
+    resource.publish(
+        TopicArn="arn:aws:sns:ap-southeast-2:451924316694:U29500-Test",
+        Message=json.dumps({'default': stac}),
+        MessageStructure='json'
+    )
+
+
+class TqdmLoggingHandler(logging.Handler):
+    def __init__(self, level=logging.NOTSET):
+        super().__init__(level)
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            tqdm.write(msg)
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+
+
+code_to_band = {
+    "B01": 'nbart_coastal_aerosol', "B02": 'nbart_blue',
+    "B03": 'nbart_green', "B04": 'nbart_red',
+    "B05": 'nbart_red_edge_1', "B06": 'nbart_red_edge_2',
+    "B07": 'nbart_red_edge_3', "B08": 'nbart_nir_1',
+    "B11": 'nbart_swir_2', "B12": 'nbart_swir_3',
+    "B8A": 'nbart_nir_2'
+}
+
+
+def add_to_eo3(assembler, dataset_dir, folder, func):
+    """
+    Helper function to add measurements to the DatasetAssembler
+
+    :param assembler: the DatasetAssembler
+    :param dataset_dir (Path): the firectory of the dataset
+    :param folder (str): the subfolder containing the measurement bands
+    :param func: a function that transforms file names to the correct band name
+    """
+    fns = [os.path.join(folder, fn) for fn in os.listdir(dataset_dir / folder) if fn[-3:] == "TIF"]
+    fns = [fn for fn in fns if "QUICKLOOK" not in fn]
+    for i, fn in enumerate(fns):
+        name = func(fn.split('.')[-2])
+        assembler.note_measurement(
+            name,
+            fn,
+            relative_to_dataset_location=True,
+        )
+
+
+def add_datetime(assembler, dataset_dir):
+    """
+    Adds the datetime from the original eo metadata.
+    """
+    eo_path = dataset_dir / "ARD-METADATA.yaml"
+    with open(eo_path) as fin:
+        eo = yaml.safe_load(fin)
+    assembler.datetime = datetime.datetime.strptime(eo['extent']['center_dt'], '%Y-%m-%dT%H:%M:%S.%fZ')
+
+
+def create_eo3(dataset_dir):
+    """
+    Creates an eo3 dataset document.
+
+    :param dataset_dir (Path): the dataset directory
+    :return: DatasetDoc of eo3 metadata
+    """
+
+    assembler = DatasetAssembler(
+            dataset_location=dataset_dir,
+            metadata_path=dataset_dir / "dummy",
+    )
+
+    if "S2A" in str(dataset_dir):
+        assembler.product_family = "s2a_ard_granule"
+    else:
+        assembler.product_family = "s2b_ard_granule"
+
+    assembler.processed_now()
+
+    add_datetime(assembler, dataset_dir)
+    add_to_eo3(assembler, dataset_dir, "NBART", lambda x: code_to_band[x.split('_')[-1]])
+    add_to_eo3(assembler, dataset_dir, "SUPPLEMENTARY", lambda x: x[3:].lower())
+    add_to_eo3(assembler, dataset_dir, "QA", lambda x: x[3:].lower().replace('combined_', ''))
+
+    crs, grid_docs, measurement_docs = assembler._measurements.as_geo_docs()
+    valid_data = assembler._measurements.consume_and_get_valid_data()
+
+    dataset = DatasetDoc(
+        id=assembler.dataset_id,
+        label=assembler.label,
+        product=ProductDoc(
+            name=assembler.names.product_name, href=assembler.names.product_uri
+        ),
+        crs=assembler._crs_str(crs) if crs is not None else None,
+        geometry=valid_data,
+        grids=grid_docs,
+        properties=assembler.properties,
+        accessories={
+            name: AccessoryDoc(path, name=name)
+            for name, path in assembler._accessories.items()
+        },
+        measurements=measurement_docs,
+        lineage=assembler._lineage,
+    )
+
+    return dataset
+
+
+if __name__ == '__main__':
+    main()
+

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -38,7 +38,7 @@ from shapely.geometry.polygon import Polygon
 NCI_DIR = '/g/data/if87/datacube/002/S2_MSI_ARD/packaged'
 S3_PATH = 'L2/sentinel-2-nbart/S2MSIARD_NBART'
 S3_BUCKET = 'dea-public-data-dev'
-WORK_DIR = Path('/home/547/kr4383/work/s2_nbart_rolling_archive')
+WORK_DIR = Path('/g/data/v10/work/s2_nbart_rolling_archive')
 
 S3 = None
 

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -133,7 +133,7 @@ def upload_dataset_without_yaml(granule_id):
               "--only-show-errors " \
               "--delete " \
               "--exclude NBAR/* " \
-              "--exclude ARD-METADATA.yaml"
+              "--exclude *NBAR_CONTIGUITY.TIF"
 
     try:
         subprocess.run(command, shell=True, check=True, stdin=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -152,8 +152,8 @@ def upload_metadata(granule_id):
     local_path = Path(NCI_DIR) / granule_id
 
     s3_path = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/"
-    s3_path_eo3 = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/eo3-ARD-METADATA.yaml"
-    s3_path_stac = f"s3://{S3_BUCKET}/{S3_PATH}/{granule_id}/stac-ARD-METADATA.json"
+    s3_path_eo3 = f"{s3_path}eo3-ARD-METADATA.yaml"
+    s3_path_stac = f"{s3_path}stac-ARD-METADATA.json"
 
     eo3 = create_eo3(local_path)
     stac = to_stac_item(

--- a/dags/sentinel_2_nbart/upload_s2_nbart.py
+++ b/dags/sentinel_2_nbart/upload_s2_nbart.py
@@ -133,6 +133,7 @@ def upload_dataset_without_yaml(granule_id):
               "--only-show-errors " \
               "--delete " \
               "--exclude NBAR/* " \
+              "--exclude ARD-METADATA.yaml" \
               "--exclude *NBAR_CONTIGUITY.TIF"
 
     try:


### PR DESCRIPTION
This PR adds a DAG + uploader script that syncs S2 NBART data from NCI to S3. The DAG is almost identical to the [nbar dag](https://github.com/GeoscienceAustralia/dea-airflow/blob/master/dags/nci_s2_upload_s3.py), and the upload script has a few additions changes.

The upload script now:

- creates eo3 and stac metadata and uploads this to S3
- sends the stac metadata to the SNS topic "U29500-Test"