### PR TITLE
Fix NCI Build DEA

### DIFF
--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -51,7 +51,7 @@ with dag:
         cd dea-notebooks/Frequently_used_code/
         module load dea/$(date +%Y%m%d)  # TODO, this will fail if run over midnight...
 
-        pytest --nbval-lax Applying_WOfS_bitmasking.ipynb Calculating_band_indices.ipynb \
+        python -m pytest --nbval-lax Applying_WOfS_bitmasking.ipynb Calculating_band_indices.ipynb \
         Contour_extraction.ipynb Exporting_GeoTIFFs.ipynb Exporting_NetCDFs.ipynb \
         Imagery_on_web_map.ipynb Integrating_external_data.ipynb Machine_learning_with_ODC.ipynb \
         Masking_data.ipynb Opening_GeoTIFFs_NetCDFs.ipynb Pan_sharpening_Brovey.ipynb \


### PR DESCRIPTION
The nci build dea dag fails during testing with 

```python
pytest: error: unrecognized arguments: --nbval-lax
```

This might be because running `pytest ....` uses a pytest installed in a different python environment w/ out `nbval`. This PR runs `python -m pytest ..` instead to try and fix this.