### PR TITLE
Delete module for today before building

### DIFF
--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -51,7 +51,7 @@ with dag:
         cd dea-notebooks/Frequently_used_code/
         module load dea/$(date +%Y%m%d)  # TODO, this will fail if run over midnight...
 
-        pytest --nbval-lax Applying_WOfS_bitmasking.ipynb Calculating_band_indices.ipynb \
+        python -m pytest --nbval-lax Applying_WOfS_bitmasking.ipynb Calculating_band_indices.ipynb \
         Contour_extraction.ipynb Exporting_GeoTIFFs.ipynb Exporting_NetCDFs.ipynb \
         Imagery_on_web_map.ipynb Integrating_external_data.ipynb Machine_learning_with_ODC.ipynb \
         Masking_data.ipynb Opening_GeoTIFFs_NetCDFs.ipynb Pan_sharpening_Brovey.ipynb \

--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -5,6 +5,7 @@
 from airflow import DAG
 from airflow.contrib.operators.ssh_operator import SSHOperator
 from datetime import datetime, timedelta
+import pytz
 
 default_args = {
     'owner': 'Damien Ayers',
@@ -22,12 +23,14 @@ dag = DAG(
     tags=['nci'],
 )
 
+timezone = pytz.timezone("Australia/Canberra")
+
 with dag:
     build_env_task = SSHOperator(
         task_id=f'build_dea_module',
         ssh_conn_id='lpgs_gadi',
         command=f"""
-        rm -r /g/data/v10/public/modules/dea/{datetime.datetime.now().strftime("%Y%m%d")}
+        rm -r /g/data/v10/public/modules/dea/{datetime.datetime.now(datetime.datetime.now(timezone)).strftime("%Y%m%d")}
         set -eux
         cd ~/dea-orchestration/
         git reset --hard

--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -26,7 +26,8 @@ with dag:
     build_env_task = SSHOperator(
         task_id=f'build_dea_module',
         ssh_conn_id='lpgs_gadi',
-        command="""
+        command=f"""
+        rm -r /g/data/v10/public/modules/dea/{datetime.datetime.now().strftime("%Y%m%d")}
         set -eux
         cd ~/dea-orchestration/
         git reset --hard

--- a/dags/nci_build_dea_module.py
+++ b/dags/nci_build_dea_module.py
@@ -5,7 +5,6 @@
 from airflow import DAG
 from airflow.contrib.operators.ssh_operator import SSHOperator
 from datetime import datetime, timedelta
-import pytz
 
 default_args = {
     'owner': 'Damien Ayers',
@@ -23,14 +22,12 @@ dag = DAG(
     tags=['nci'],
 )
 
-timezone = pytz.timezone("Australia/Canberra")
-
 with dag:
     build_env_task = SSHOperator(
         task_id=f'build_dea_module',
         ssh_conn_id='lpgs_gadi',
         command=f"""
-        rm -r /g/data/v10/public/modules/dea/{datetime.datetime.now(datetime.datetime.now(timezone)).strftime("%Y%m%d")}
+        rm -r /g/data/v10/public/modules/dea/$(date +%Y%m%d)
         set -eux
         cd ~/dea-orchestration/
         git reset --hard


### PR DESCRIPTION
This PR deletes the module with todays date before attempting to build the module.

For some reason my recent build didn't use the latest `dea-cogger` from https://packages.dea.ga.gov.au/dea-cogger/ so I'm re-building the module.