### PR TITLE
Revert "bump up wagl pod resource requests"

### DIFF
--- a/dags/wagl/k8s_wagl_nrt.py
+++ b/dags/wagl/k8s_wagl_nrt.py
@@ -388,8 +388,8 @@ with pipeline:
             ),
             get_logs=True,
             resources={
-                "request_cpu": "1600m",
-                "request_memory": "15Gi",
+                "request_cpu": "1000m",
+                "request_memory": "12Gi",
             },
             volumes=[ancillary_volume],
             volume_mounts=[ancillary_volume_mount],


### PR DESCRIPTION
This reverts commit 4a3befccbf183bd16413eb4770ed0a30197eb7c7.

Nodes are not matching anymore. 