### PR TITLE
Add extra properties

### DIFF
--- a/dags/sentinel_2_nbart/nbart_fix_metadata.py
+++ b/dags/sentinel_2_nbart/nbart_fix_metadata.py
@@ -42,7 +42,7 @@ default_args = {
 }
 
 dag = DAG(
-    'nbart_fix_metadata',
+    'nbart_fix_metadata_v2',
     doc_md=__doc__,
     default_args=default_args,
     catchup=True,

--- a/dags/sentinel_2_nbart/nbart_s2b_fix_metadata.py
+++ b/dags/sentinel_2_nbart/nbart_s2b_fix_metadata.py
@@ -42,7 +42,7 @@ default_args = {
 }
 
 dag = DAG(
-    'nbart_s2b_fix_metadata',
+    'nbart_s2b_fix_metadata_v2',
     doc_md=__doc__,
     default_args=default_args,
     catchup=True,

--- a/scripts/upload_s2_nbart.py
+++ b/scripts/upload_s2_nbart.py
@@ -147,7 +147,7 @@ def upload_metadata(granule_id):
     s3_eo3_path = f"{s3_path}eo3-ARD-METADATA.yaml"
     s3_stac_path = f"{s3_path}stac-ARD-METADATA.json"
 
-    eo3 = create_eo3(local_path)
+    eo3 = create_eo3(local_path, granule_id)
     stac = to_stac_item(
         eo3,
         stac_item_destination_url=s3_stac_path,
@@ -219,7 +219,7 @@ def add_datetime(assembler, granule_dir):
     assembler.datetime = datetime.datetime.strptime(eo['extent']['center_dt'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
-def create_eo3(granule_dir):
+def create_eo3(granule_dir, granule_id):
     """
     Creates an eo3 document.
 
@@ -243,8 +243,10 @@ def create_eo3(granule_dir):
 
     if "S2A" in str(granule_dir):
         assembler.product_family = "s2a_ard_granule"
+        platform = "SENTINEL_2A"        
     else:
         assembler.product_family = "s2b_ard_granule"
+        platform = "SENTINEL_2B"
 
     assembler.processed_now()
 
@@ -261,6 +263,8 @@ def create_eo3(granule_dir):
     assembler.properties["gqa:error_message"] = metadata["gqa"]["error_message"]
     assembler.properties["gqa:final_gcp_count"] =metadata["gqa"]["final_gcp_count"]
     assembler.properties["gqa:ref_source"] = metadata["gqa"]["ref_source"]
+    assembler.properties["sentinel:datatake_start_datetime"] = granule_id.split("_")[-4]
+    assembler.properties["eo:platform"] = platform
 
     for key in ["abs_iterative_mean", "abs", "iterative_mean", "iterative_stddev", "mean", "stddev"]:
         assembler.properties[f"gqa:{key}_xy"] = metadata["gqa"]["residual"][key]["xy"]


### PR DESCRIPTION
This PR adds some extra properties to nbart metadata required for `alchemist`. I've tested these properties with the fixup dags and `alchemist` can now be run!

It also changes the version of the fixup dags to enable better monitoring of their progress.

Once this is merged I'll restart all nbart upload dag runs that are running to ensure a consistent state, and then run the fixup dags.