### PR TITLE
Migrate utility to v2

### DIFF
--- a/.github/workflows/dag_lint.yaml
+++ b/.github/workflows/dag_lint.yaml
@@ -50,6 +50,7 @@ jobs:
         run: |
           pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]==1.10.15 -c constraints.txt
           pip install pylint pylint-airflow
+          pip install apache-airflow-backport-providers-kubernetes
           pip install -r requirements.txt
           pylint --load-plugins=pylint_airflow --disable=C,W --disable=similarities dags
       - name: setup airflow and check dags list

--- a/.github/workflows/dag_lint.yaml
+++ b/.github/workflows/dag_lint.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]==1.10.15 -c constraints.txt
           pip install pylint pylint-airflow
-          pip install apache-airflow-backport-providers-kubernetes
+          pip install apache-airflow-backport-providers-cncf-kubernetes
           pip install -r requirements.txt
           pylint --load-plugins=pylint_airflow --disable=C,W --disable=similarities dags
       - name: setup airflow and check dags list

--- a/.github/workflows/dag_test.yaml
+++ b/.github/workflows/dag_test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install airflow and run pylint
         run: |
           pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]==1.10.15 -c constraints.txt
-          pip install apache-airflow-backport-providers-kubernetes
+          pip install apache-airflow-backport-providers-cncf-kubernetes
           pip install pylint pylint-airflow
           pip install -r requirements.txt
           pylint --load-plugins=pylint_airflow --disable=C,W --disable=similarities dags

--- a/.github/workflows/dag_test.yaml
+++ b/.github/workflows/dag_test.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Install airflow and run pylint
         run: |
           pip install apache-airflow[aws,kubernetes,postgres,redis,ssh,celery]==1.10.15 -c constraints.txt
+          pip install apache-airflow-backport-providers-kubernetes
           pip install pylint pylint-airflow
           pip install -r requirements.txt
           pylint --load-plugins=pylint_airflow --disable=C,W --disable=similarities dags

--- a/dags/utility/utility_odc_db_backup_to_s3.py
+++ b/dags/utility/utility_odc_db_backup_to_s3.py
@@ -10,7 +10,8 @@ from datetime import date, datetime, timedelta
 
 from airflow import DAG
 from airflow.kubernetes.secret import Secret
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+# from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from textwrap import dedent
 from infra.images import INDEXER_IMAGE
 from infra.variables import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 kubernetes
 airflow-kubernetes-job-operator == 1.0.18
 SQLAlchemy == 1.3.23
+apache-airflow-backport-providers-cncf-kubernetes


### PR DESCRIPTION
starting to migrate import path to v2 standard, this is enabled by upgrade-backporter

https://airflow.apache.org/docs/apache-airflow/stable/upgrading-to-2.html#step-4-import-operators-from-backport-providers

add to requirement.txt for real server testing and monitoring before cutting over