### PR TITLE
automated_reporting: fixed incorrect kwargs for s2 completeness dags

### DIFF
--- a/dags/automated_reporting/developement_dags/rep_s2_completeness_dev.py
+++ b/dags/automated_reporting/developement_dags/rep_s2_completeness_dev.py
@@ -107,7 +107,7 @@ with dag:
     }
     completeness_kwargs_ard.update(completeness_kwargs)
     compute_sentinel_ard_completeness = PythonOperator(
-        task_id="compute_sentinel_ard_completeness",
+        task_id="compute_s2_ard_completeness",
         python_callable=s2_completeness_ard_task,
         op_kwargs=completeness_kwargs_ard,
         provide_context=True,
@@ -127,9 +127,9 @@ with dag:
     }
     completeness_kwargs_ard_prov.update(completeness_kwargs)
     compute_sentinel_ard_prov_completeness = PythonOperator(
-        task_id="compute_sentinel_ard_completeness_prov",
+        task_id="compute_s2_ard_completeness_prov",
         python_callable=s2_completeness_ard_task,
-        op_kwargs=completeness_kwargs,
+        op_kwargs=completeness_kwargs_ard_prov,
         provide_context=True,
     )
 
@@ -141,7 +141,7 @@ with dag:
     compute_sentinel_wo_completeness = PythonOperator(
         task_id="compute_sentinel_wo_completeness",
         python_callable=s2_completeness_derivative_task,
-        op_kwargs=completeness_kwargs,
+        op_kwargs=completeness_kwargs_wo,
         provide_context=True,
     )
 

--- a/dags/automated_reporting/rep_expire_completeness_prod.py
+++ b/dags/automated_reporting/rep_expire_completeness_prod.py
@@ -67,6 +67,9 @@ with dag:
         "usgs_ls8c_level1_nrt_c2",
         "usgs_ls7e_level1_nrt_c2",
         "ga_s2_wo_3",
+        "ga_s2am_ard_provisional_3",
+        "ga_s2bm_ard_provisional_3",
+        "ga_s2_ba_provisional_3",
     ]
 
     def create_task(product_id):

--- a/dags/automated_reporting/rep_s2_completeness_prod.py
+++ b/dags/automated_reporting/rep_s2_completeness_prod.py
@@ -106,7 +106,7 @@ with dag:
     }
     completeness_kwargs_ard.update(completeness_kwargs)
     compute_sentinel_ard_completeness = PythonOperator(
-        task_id="compute_sentinel_ard_completeness",
+        task_id="compute_s2_ard_completeness",
         python_callable=s2_completeness_ard_task,
         op_kwargs=completeness_kwargs_ard,
         provide_context=True,
@@ -126,9 +126,9 @@ with dag:
     }
     completeness_kwargs_ard_prov.update(completeness_kwargs)
     compute_sentinel_ard_prov_completeness = PythonOperator(
-        task_id="compute_sentinel_ard_completeness_prov",
+        task_id="compute_s2_ard_completeness_prov",
         python_callable=s2_completeness_ard_task,
-        op_kwargs=completeness_kwargs,
+        op_kwargs=completeness_kwargs_ard_prov,
         provide_context=True,
     )
 


### PR DESCRIPTION
Fixed an issue in previous PR with the incorrect kwargs being passed to s2 completeness task, and shortened task ids slightly so they display better in the UI. 