### PR TITLE
Disable pod persistence.

### DIFF
--- a/dags/collection3/odc-db/k8s_index_s2_derivatves_odc.py
+++ b/dags/collection3/odc-db/k8s_index_s2_derivatves_odc.py
@@ -102,5 +102,5 @@ with dag:
             task_id=f"indexing-task-{product}",
             get_logs=True,
             affinity=ONDEMAND_NODE_AFFINITY,
-            is_delete_operator_pod=False,
+            is_delete_operator_pod=True,
         )


### PR DESCRIPTION
Burn vector processing pods should be deleted after execution has completed.