### PR TITLE
More import fixes for Airflow 2.2.2

### DIFF
--- a/dags/automated_reporting/developement_dags/rep_expire_completeness_dev.py
+++ b/dags/automated_reporting/developement_dags/rep_expire_completeness_dev.py
@@ -8,7 +8,8 @@ values and the aoi summary values.
 
 import logging
 from datetime import datetime as dt
-from datetime import timedelta, timezone
+from datetime import timedelta
+import pendulum
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
@@ -26,10 +27,12 @@ from automated_reporting.tasks.expire_completeness import (
 
 log = logging.getLogger("airflow.task")
 
+utc_tz = pendulum.timezone("UTC")
+
 default_args = {
     "owner": "Tom McAdam",
     "depends_on_past": False,
-    "start_date": dt(2021, 7, 12, tzinfo=timezone.utc),
+    "start_date": dt(2021, 7, 12, tzinfo=utc_tz),
     "email": ["tom.mcadam@ga.gov.au"],
     "email_on_failure": False,
     "email_on_retry": False,

--- a/dags/automated_reporting/developement_dags/rep_nrt_simple_latency_dev.py
+++ b/dags/automated_reporting/developement_dags/rep_nrt_simple_latency_dev.py
@@ -11,12 +11,13 @@ import os
 import pathlib
 import logging
 from datetime import datetime as dt
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.configuration import conf
 from airflow.operators.python import PythonOperator
 from airflow.hooks.base_hook import BaseHook
+import pendulum
 
 from automated_reporting import connections
 from automated_reporting.databases import schemas
@@ -30,10 +31,12 @@ from automated_reporting.tasks.sns_latency import task as sns_latency_task
 
 log = logging.getLogger("airflow.task")
 
+utc_tz = pendulum.timezone("UTC")
+
 default_args = {
     "owner": "Tom McAdam",
     "depends_on_past": False,
-    "start_date": dt(2021, 7, 5, tzinfo=timezone.utc),
+    "start_date": dt(2021, 7, 5, tzinfo=utc_tz),
     "email": ["tom.mcadam@ga.gov.au"],
     "email_on_failure": True,
     "email_on_retry": False,

--- a/dags/automated_reporting/developement_dags/rep_usgs_monitoring_dev.py
+++ b/dags/automated_reporting/developement_dags/rep_usgs_monitoring_dev.py
@@ -10,13 +10,14 @@ This DAG
 """
 import os
 import pathlib
-from datetime import datetime as dt, timedelta, timezone
+from datetime import datetime as dt, timedelta
 
 from airflow import DAG
 from airflow.configuration import conf
 from airflow.operators.python import PythonOperator
 from airflow.models import Variable
 from airflow.hooks.base_hook import BaseHook
+import pendulum
 
 from automated_reporting.variables import M2M_API_REP_CREDS
 from automated_reporting import connections
@@ -39,10 +40,12 @@ from automated_reporting.tasks.usgs_aquisitions import task as usgs_acquisitions
 from automated_reporting.tasks.usgs_insert_hg_l0 import task as usgs_insert_hg_l0_task
 from automated_reporting.tasks.usgs_insert_acqs import task as usgs_insert_acqs_task
 
+utc_tz = pendulum.timezone("UTC")
+
 default_args = {
     "owner": "Tom McAdam",
     "depends_on_past": False,
-    "start_date": dt(2021, 9, 23, tzinfo=timezone.utc),
+    "start_date": dt(2021, 9, 23, tzinfo=utc_tz),
     "email": ["tom.mcadam@ga.gov.au"],
     "email_on_failure": True,
     "email_on_retry": False,

--- a/dags/automated_reporting/rep_s2_completeness_prod.py
+++ b/dags/automated_reporting/rep_s2_completeness_prod.py
@@ -14,13 +14,14 @@ import os
 import pathlib
 import logging
 from datetime import datetime as dt
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.configuration import conf
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
 from airflow.hooks.base_hook import BaseHook
+import pendulum
 
 from automated_reporting import variables
 from automated_reporting import connections
@@ -41,10 +42,11 @@ from automated_reporting.tasks.s2_ard_completeness import (
 
 log = logging.getLogger("airflow.task")
 
+utc_tz = pendulum.timezone("UTC")
 default_args = {
     "owner": "Tom McAdam",
     "depends_on_past": False,
-    "start_date": dt(2021, 5, 1, tzinfo=timezone.utc),
+    "start_date": dt(2021, 5, 1, tzinfo=utc_tz),
     "email": ["tom.mcadam@ga.gov.au"],
     "email_on_failure": False,
     "email_on_retry": False,

--- a/dags/automated_reporting/rep_usgs_monitoring_prod.py
+++ b/dags/automated_reporting/rep_usgs_monitoring_prod.py
@@ -10,7 +10,8 @@ This DAG
 """
 import os
 import pathlib
-from datetime import datetime as dt, timedelta, timezone
+from datetime import datetime as dt, timedelta
+import pendulum
 
 from airflow import DAG
 from airflow.configuration import conf
@@ -39,10 +40,12 @@ from automated_reporting.tasks.usgs_aquisitions import task as usgs_acquisitions
 from automated_reporting.tasks.usgs_insert_hg_l0 import task as usgs_insert_hg_l0_task
 from automated_reporting.tasks.usgs_insert_acqs import task as usgs_insert_acqs_task
 
+utc_tz = pendulum.timezone("UTC")
+
 default_args = {
     "owner": "Tom McAdam",
     "depends_on_past": False,
-    "start_date": dt(2021, 8, 16, tzinfo=timezone.utc),
+    "start_date": dt(2021, 8, 16, tzinfo=utc_tz),
     "email": ["tom.mcadam@ga.gov.au"],
     "email_on_failure": True,
     "email_on_retry": False,


### PR DESCRIPTION
Need to use pendulum timezone instead of `datetime.timezone` more of the same as #579 