### PR TITLE
automated_reporting: replaced next_execution_date with data_interval_end

### DIFF
--- a/dags/automated_reporting/tasks/latency_from_completeness.py
+++ b/dags/automated_reporting/tasks/latency_from_completeness.py
@@ -9,12 +9,12 @@ from automated_reporting.databases import reporting_db
 log = logging.getLogger("airflow.task")
 
 
-def task(rep_conn, next_execution_date, completeness_summary, **kwargs):
+def task(rep_conn, data_interval_end, completeness_summary, **kwargs):
     """
     Task for inserting latency from the latest completeness record
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # Convert pendulum to python datetime to make stripping timezone possible
     execution_date = helpers.python_dt(execution_date)

--- a/dags/automated_reporting/tasks/s2_ard_completeness.py
+++ b/dags/automated_reporting/tasks/s2_ard_completeness.py
@@ -19,7 +19,7 @@ def filter_expected_to_sensor(expected_products, sensor):
 def task(
     s2a,
     s2b,
-    next_execution_date,
+    data_interval_end,
     days,
     rep_conn,
     odc_conn,
@@ -31,7 +31,7 @@ def task(
     Task to compute Sentinel2 ARD completeness
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # query Copernicus API for for all S2 L1 products for last X days
     expected_products = copernicus_api.query(

--- a/dags/automated_reporting/tasks/s2_deriv_completeness.py
+++ b/dags/automated_reporting/tasks/s2_deriv_completeness.py
@@ -44,7 +44,7 @@ def map_odc_to_expected(datasets):
 def task(
     upstream,
     target,
-    next_execution_date,
+    data_interval_end,
     days,
     rep_conn,
     odc_conn,
@@ -55,7 +55,7 @@ def task(
     Task to compute Sentinel2 derivative completeness
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # query ODC for for all upstream products for last X days
     expected_datasets_odc = list()

--- a/dags/automated_reporting/tasks/s2_l1_completeness.py
+++ b/dags/automated_reporting/tasks/s2_l1_completeness.py
@@ -19,7 +19,7 @@ def filter_expected_to_sensor(expected_products, sensor):
 def task(
     s2a,
     s2b,
-    next_execution_date,
+    data_interval_end,
     days,
     rep_conn,
     aux_data_path,
@@ -30,7 +30,7 @@ def task(
     Task to compute Sentinel2 ARD completeness
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # query Copernicus API for for all S2 L1 products for last X days
     expected_products = copernicus_api.query(

--- a/dags/automated_reporting/tasks/simple_latency.py
+++ b/dags/automated_reporting/tasks/simple_latency.py
@@ -10,12 +10,12 @@ log = logging.getLogger("airflow.task")
 
 
 # Task callable
-def task(rep_conn, odc_conn, next_execution_date, product_name, **kwargs):
+def task(rep_conn, odc_conn, data_interval_end, product_name, **kwargs):
     """
     Task to query AWS ODC with supplied `product_name` and insert a summary of latest timestamps into reporting DB
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # Convert pendulum to python datetime to make stripping timezone possible
     execution_date = helpers.python_dt(execution_date)

--- a/dags/automated_reporting/tasks/sns_latency.py
+++ b/dags/automated_reporting/tasks/sns_latency.py
@@ -9,13 +9,13 @@ from automated_reporting.databases import reporting_db
 log = logging.getLogger("airflow.task")
 
 
-def task(rep_conn, next_execution_date, pipeline, product_id, **kwargs):
+def task(rep_conn, data_interval_end, pipeline, product_id, **kwargs):
     """
     Task to query reporting DB SNS table with supplied `product_name`
     and insert a summary of latest timestamps into reporting DB
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     # Convert pendulum to python datetime to make stripping timezone possible
     execution_date = helpers.python_dt(execution_date)

--- a/dags/automated_reporting/tasks/usgs_aquisitions.py
+++ b/dags/automated_reporting/tasks/usgs_aquisitions.py
@@ -9,12 +9,12 @@ from automated_reporting.utilities import m2m_api, helpers
 log = logging.getLogger("airflow.task")
 
 
-def task(product_ids, next_execution_date, m2m_credentials, aux_data_path, **kwargs):
+def task(product_ids, data_interval_end, m2m_credentials, aux_data_path, **kwargs):
     """
     Task to fetch recent USGS aquisitions and write to reporting database
     """
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
 
     task_output = list()
 

--- a/dags/automated_reporting/tasks/usgs_ard_completeness.py
+++ b/dags/automated_reporting/tasks/usgs_ard_completeness.py
@@ -12,9 +12,7 @@ from datetime import timedelta
 log = logging.getLogger("airflow.task")
 
 
-def task(
-    next_execution_date, product, rep_conn, odc_conn, days, aux_data_path, **kwargs
-):
+def task(data_interval_end, product, rep_conn, odc_conn, days, aux_data_path, **kwargs):
     """
     Main function
     :return:
@@ -22,7 +20,7 @@ def task(
     log.info("Starting completness calc for: {}".format(product["odc_code"]))
 
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
     execution_date = helpers.python_dt(execution_date)
 
     # Get path row list

--- a/dags/automated_reporting/tasks/usgs_l1_completeness.py
+++ b/dags/automated_reporting/tasks/usgs_l1_completeness.py
@@ -10,7 +10,7 @@ from automated_reporting.databases import reporting_db_usgs, reporting_db
 log = logging.getLogger("airflow.task")
 
 
-def task(next_execution_date, product, rep_conn, days, aux_data_path, **kwargs):
+def task(data_interval_end, product, rep_conn, days, aux_data_path, **kwargs):
     """
     Main function
     :return:
@@ -18,7 +18,7 @@ def task(next_execution_date, product, rep_conn, days, aux_data_path, **kwargs):
     log.info("Starting completness calc for: {}".format(product["rep_code"]))
 
     # Correct issue with running at start of scheduled period
-    execution_date = next_execution_date
+    execution_date = data_interval_end
     execution_date = helpers.python_dt(execution_date)
 
     # Get path row list

--- a/dags/automated_reporting/tests/integration_tests/test_s2_completeness.py
+++ b/dags/automated_reporting/tests/integration_tests/test_s2_completeness.py
@@ -27,7 +27,7 @@ class CompletenessTests_S2_L1(unittest.TestCase):
 
     completeness_kwargs = {
         "days": 1,
-        "next_execution_date": parser.isoparse("2021-09-03T20:30:00.000000+10"),
+        "data_interval_end": parser.isoparse("2021-09-03T20:30:00.000000+10"),
         "rep_conn": "rep_conn",
         "copernicus_api_credentials": {},
         "aux_data_path": "some_data_path",
@@ -129,7 +129,7 @@ class CompletenessTests_S2_ARD(unittest.TestCase):
 
     completeness_kwargs = {
         "days": 1,
-        "next_execution_date": parser.isoparse("2021-09-03T20:30:00.000000+10"),
+        "data_interval_end": parser.isoparse("2021-09-03T20:30:00.000000+10"),
         "rep_conn": "rep_conn",
         "odc_conn": "odc_conn",
         "copernicus_api_credentials": {},
@@ -297,7 +297,7 @@ class CompletenessTests_S2_Deriv(unittest.TestCase):
 
     completeness_kwargs = {
         "days": 1,
-        "next_execution_date": parser.isoparse("2021-09-03T20:30:00.000000+10"),
+        "data_interval_end": parser.isoparse("2021-09-03T20:30:00.000000+10"),
         "rep_conn": "rep_conn",
         "odc_conn": "odc_conn",
         "copernicus_api_credentials": {},

--- a/dags/automated_reporting/tests/integration_tests/test_usgs_completeness.py
+++ b/dags/automated_reporting/tests/integration_tests/test_usgs_completeness.py
@@ -26,7 +26,7 @@ log.addHandler(handler)
 class CompletenessTests_USGS_L1(unittest.TestCase):
 
     completeness_kwargs = {
-        "next_execution_date": parser.isoparse("2021-05-20T20:30:00.000000+00:00"),
+        "data_interval_end": parser.isoparse("2021-05-20T20:30:00.000000+00:00"),
         "rep_conn": "rep_conn",
         # "task_instance": task_instance,
         "aux_data_path": "some_data_path",
@@ -160,7 +160,7 @@ class CompletenessTests_USGS_L1(unittest.TestCase):
 class CompletenessTests_USGS_ARD(unittest.TestCase):
 
     completeness_kwargs = {
-        "next_execution_date": parser.isoparse("2021-05-20T20:30:00.000000+00:00"),
+        "data_interval_end": parser.isoparse("2021-05-20T20:30:00.000000+00:00"),
         "rep_conn": "rep_conn",
         "odc_conn": "odc_conn",
         "product": dict(acq_code="sdfsdf", odc_code="ga_ls8c_ard_provisional_3"),

--- a/dags/automated_reporting/tests/misc_tests/m2m_test.py
+++ b/dags/automated_reporting/tests/misc_tests/m2m_test.py
@@ -35,13 +35,13 @@ def main():
 
     acquisitions = usgs_aquisitions.task(
         product_ids=product_ids,
-        next_execution_date=dt.now(),
+        data_interval_end=dt.now(),
         m2m_credentials=dict(config["usgs_m2m"]),
         aux_data_path=os.path.join(AR_FOLDER, "aux_data"),
     )
 
     usgs_insert_hg_l0.task(
-        next_execution_date=dt.now(),
+        data_interval_end=dt.now(),
         rep_conn=dict(config["reporting_db"]),
         acquisitions=acquisitions,
     )

--- a/dags/automated_reporting/tests/misc_tests/sns_currency_test.py
+++ b/dags/automated_reporting/tests/misc_tests/sns_currency_test.py
@@ -34,7 +34,7 @@ def main():
     sns_latency.task(
         pipeline="S2A_MSIL1C",
         product_id="s2a_l1_nrt",
-        next_execution_date=parser.isoparse("2021-09-21T11:45:00.000000+00:00"),
+        data_interval_end=parser.isoparse("2021-09-21T11:45:00.000000+00:00"),
         rep_conn=dict(config["reporting_db"]),
     )
 


### PR DESCRIPTION
This is in response to a psycopg2 error in s2 completeness monitoring which has been failing since the 2.2.2 upgrade. Fixing the deprecation warning seems to fix the error with psycopg2 when testing locally. Not sure why.