### PR TITLE
add sftp constraint

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 SQLAlchemy==1.3.23
 boto3==1.17.49
 WTForms==2.3.3
+apache-airflow-providers-sftp==2.2.0


### PR DESCRIPTION
fixes
```
************* Module operators.ssh_operators
plugins/operators/ssh_operators.py:10:0: E0611: No name '_make_intermediate_dirs' in module 'airflow.providers.sftp.operators.sftp' (no-name-in-module)
```