### PR TITLE
Update webapps for ga_s2_wo_provisional_3 in dev

### DIFF
--- a/dags/webapp_update/update_list.py
+++ b/dags/webapp_update/update_list.py
@@ -15,6 +15,7 @@ OWS_UPDATE_LIST = (
     "ga_ls_ard_provisional_3",
     "s2_nrt_provisional_granule_nbar_t",
     "ga_s2_ba_provisional_3",
+    "ga_s2_wo_provisional_3",
 )
 
 EXPLORER_UPDATE_LIST = (
@@ -33,4 +34,5 @@ EXPLORER_UPDATE_LIST = (
     "ga_s2am_ard_provisional_3",
     "ga_s2bm_ard_provisional_3",
     "ga_s2_ba_provisional_3",
+    "ga_s2_wo_provisional_3",
 )


### PR DESCRIPTION
`ga_s2_wo_provisional_3` is a provisional NRT product running in dev. It's produced via an alchemist pipeline which automatically gets indexed, but Explorer and OWS also need to be updated.