### PR TITLE
Sync ga_ls9c_ard_3 from NCI

### DIFF
--- a/dags/collection3/nci_c3_upload_s3.py
+++ b/dags/collection3/nci_c3_upload_s3.py
@@ -33,7 +33,7 @@ from airflow.providers.ssh.operators.ssh import SSHOperator
 
 local_tz = pendulum.timezone("Australia/Canberra")
 
-collection3_products = ["ga_ls5t_ard_3", "ga_ls7e_ard_3", "ga_ls8c_ard_3"]
+collection3_products = ["ga_ls5t_ard_3", "ga_ls7e_ard_3", "ga_ls8c_ard_3", "ga_ls9c_ard_3"]
 
 # Split embedded SQL and Shell Script hunks to enable fancy IDE highlighting and error checking
 # language=SQL


### PR DESCRIPTION
Adding `ga_ls9c_ard_3` to sync from NCI to AWS.

I expect this to behave similarly to `ga_ls8c_ard_3`. It has same properties: strip out NBAR, produced into same NCI directory as the others.

Plan for deployment:
- [ ] manually test running `c3_to_s3_rolling.py` for LS9 data against testing buckets/topics for sanity/paranoia
- [ ] deploy change directly to prod - check that the LS8 data still functions
- [ ] retrospectively run DAG in the past, to cover LS9 data, as it's not automatically producing new data and only has one or two observations
- [ ] If things break, roll back the change