### PR TITLE
Add ga_ls9c_ard_3 for landsat indexing

### DIFF
--- a/dags/collection3/odc-db/k8s_index_ls_c3_odc.py
+++ b/dags/collection3/odc-db/k8s_index_ls_c3_odc.py
@@ -48,7 +48,7 @@ DEFAULT_ARGS = {
     "retry_delay": timedelta(minutes=5),
     "index_sqs_queue": C3_INDEXING_SQS_QUEUE_NAME,
     "archive_sqs_queue": C3_ARCHIVAL_SQS_QUEUE_NAME,
-    "products": "ga_ls5t_ard_3 ga_ls7e_ard_3 ga_ls8c_ard_3",
+    "products": "ga_ls5t_ard_3 ga_ls7e_ard_3 ga_ls8c_ard_3 ga_ls9c_ard_3",
     "env_vars": {
         "DB_HOSTNAME": DB_HOSTNAME,
         "DB_DATABASE": DB_DATABASE,


### PR DESCRIPTION
I expect this to not behave any differently from the other Landsat products

Related PRs
* Airflow dag which syncs NCI to AWS:  https://github.com/GeoscienceAustralia/dea-airflow/pull/918